### PR TITLE
Add CI step to build the site

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,3 +49,6 @@ jobs:
               run: |
                   pnpm next telemetry disable
                   pnpm lint
+
+            - name: Build project
+              run: pnpm build --debug --no-lint


### PR DESCRIPTION
This sets up our CI to also try to build the project, which will catch any errors that might be missed by `pnpm lint`.