### PR TITLE
Fix improper display of team pictures on homepage

### DIFF
--- a/src/app/[locale]/HomeComponents/TeamSection/Team.tsx
+++ b/src/app/[locale]/HomeComponents/TeamSection/Team.tsx
@@ -53,7 +53,7 @@ const Team = () => {
 
                 <div className="relative bg-transparent">
                     <Marquee pauseOnHover speed={40}>
-                        <div className="flex flex-row">
+                        <div className="mb-16 flex flex-row pt-2">
                             {membersData.map((member, index) => (
                                 <div key={index} className="relative">
                                     <CircleImage


### PR DESCRIPTION
On hover, the team pictures would be cut off at the top, and the text box in the centre to display information would be on top of the footer. This fixes both problems.