### PR TITLE
Add link to GitHub in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -35,24 +35,27 @@ export default function Footer() {
                         <p className="text-thistle">
                             &copy;&nbsp;2014&ndash;{new Date().getFullYear()}
                         </p>
-                        <div className="flex w-full justify-center">
-                            <Button variant="ghost-plain" className="gap-2 text-thistle" asChild>
-                                <Link
-                                    href="https://github.com/uOttawaSESA/sesa-website/"
-                                    target="_blank"
-                                >
-                                    <Image
-                                        src="/icons/github-plain.svg"
-                                        alt="GitHub"
-                                        width={24}
-                                        height={24}
-                                        className="h-6 w-6"
-                                    />
-                                    View Source
-                                    <ExternalLink />
-                                </Link>
-                            </Button>
-                        </div>
+                        {/* Note: I've aligned this button with `-left-3` instead of making the padding 0 so that the hover animation still looks ok */}
+                        <Button
+                            variant="ghost-plain"
+                            className="-left-3 gap-2 p-3 text-sm text-thistle md:text-base"
+                            asChild
+                        >
+                            <Link
+                                href="https://github.com/uOttawaSESA/sesa-website/"
+                                target="_blank"
+                            >
+                                <Image
+                                    src="/icons/github-plain.svg"
+                                    alt="GitHub"
+                                    width={20}
+                                    height={20}
+                                    className="h-5 w-5"
+                                />
+                                View Source
+                                <ExternalLink className="h-5 w-5" />
+                            </Link>
+                        </Button>
                     </div>
 
                     <div className="flex flex-wrap justify-between gap-4 text-left sm:flex-nowrap lg:gap-36">


### PR DESCRIPTION
Closes #145

This is what it looks like as of now:

<img width="1702" height="517" alt="Screenshot of updated footer with GitHub link." src="https://github.com/user-attachments/assets/1bfeef8f-c6c6-4234-bfaf-d00f66047372" />

---

I could also left-justify the button if we think it looks better:

<img width="1711" height="520" alt="Screenshot of the same thing, but with the button left- instead of center-aligned." src="https://github.com/user-attachments/assets/c10bcb83-6e9d-4011-bda8-95a43d60df0f" />
