### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # Sensitive files
-**/LICENSE    @uOttawaSESA/co-directors
-**/CODEOWNERS @uOttawaSESA/co-directors
+LICENSE    @uOttawaSESA/co-directors
+CODEOWNERS @uOttawaSESA/co-directors
 
 # CI/CD
-.github/workflows/      @uOttawaSESA/devops
-.husky/                 @uOttawaSESA/devops
-**/.lintstagedrc.*      @uOttawaSESA/devops
-**/lint-staged.config.* @uOttawaSESA/devops
+.github/workflows/   @uOttawaSESA/devops
+.husky/              @uOttawaSESA/devops
+.lintstagedrc.*      @uOttawaSESA/devops
+lint-staged.config.* @uOttawaSESA/devops
 
 # Build-related
-**/next.config.*  @uOttawaSESA/devops
-**/package.json   @uOttawaSESA/devops
-**/pnpm-lock.yaml @uOttawaSESA/devops
-**/tsconfig.json  @uOttawaSESA/devops
+next.config.*  @uOttawaSESA/devops
+package.json   @uOttawaSESA/devops
+pnpm-lock.yaml @uOttawaSESA/devops
+tsconfig.json  @uOttawaSESA/devops


### PR DESCRIPTION
Used to automatically request review on certain important files.

For now, we can't actually _enforce_ codeowners (i.e. require their review on PRs that affect their files). However, we will be able to add branch protection rules to do this once the repository is public.