### PR TITLE
Add i18n SSG to policies page

### DIFF
--- a/src/app/[locale]/policies/page.tsx
+++ b/src/app/[locale]/policies/page.tsx
@@ -2,6 +2,10 @@ import { useTranslations } from "next-intl";
 
 import type { Metadata } from "next";
 
+// Precompile i18n
+import localeParams from "@/app/data/locales";
+export const generateStaticParams = localeParams;
+
 export const metadata: Metadata = {
     title: "Policies | Software Engineering Student Association",
     description: "Policies for our website.",


### PR DESCRIPTION
# Description

Adds the missing static site generation config to the policies page.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [ ] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [ ] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key