### PR TITLE
Use i18n for "View Source" text in footer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -327,6 +327,7 @@
         "constitution": "Constitution",
         "contact": "Contact",
         "blurb": "We connect SEG & EECS students with software engineering industry professionals, providing resources and support.",
-        "back_to_top": "Back to top"
+        "back_to_top": "Back to top",
+        "view_source_btn": "View Source"
     }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -52,7 +52,7 @@ export default function Footer() {
                                     height={20}
                                     className="h-5 w-5"
                                 />
-                                View Source
+                                {t("view_source_btn")}
                                 <ExternalLink className="h-5 w-5" />
                             </Link>
                         </Button>


### PR DESCRIPTION
# Description

The button was not using i18n keys.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key