### PR TITLE
Fix lint-staged command

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-    "**/*": "pnpm exec biome check --write"
+    "**/*": "pnpm exec biome check --write --no-errors-on-unmatched"
 }


### PR DESCRIPTION
# Description

Prevents errors from happening when the only files in the commit cannot be formatted.