### PR TITLE
typo in SESA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uOttawa Software Engineering Student Association (SESA)
+# uOttawa Software Engineering Student's Association (SESA)
 
 This is the repository for the main SESA website.
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,6 +1,6 @@
 {
     "homepage": {
-        "we_are_sesa": "Software Engineering Students Association",
+        "we_are_sesa": "Software Engineering Student's Association",
         "bridging_the_gap_hl": "Bridging the gap",
         "bridging_the_gap": "between students and industry professionals",
         "purpose": "We connect SEG & EECS students with industry professionals in software engineering, providing resources, networking, and career development.",
@@ -41,7 +41,7 @@
 
         "faq_q1": {
             "title": "WHAT IS SESA?",
-            "answer": "SESA is the University of Ottawa **Software Engineering Students Association**! We're an informally and independently run student organization with the mission of enriching SEG student life, promoting software engineering as a field, and supporting students academically and professionally as they begin their careers.\n\nOur initiatives are designed to help students succeed both in and out of the classroom. These include:\n\n- **Professional development workshops** and networking events for students\n- **Academic support** through study resources\n- **Social and community-building events** to bring students together\n- **Student outreach** to inspire and engage future engineers\n- **Advocacy** for the SEG student voice within uOttawa"
+            "answer": "SESA is the University of Ottawa **Software Engineering Student's Association**! We're an informally and independently run student organization with the mission of enriching SEG student life, promoting software engineering as a field, and supporting students academically and professionally as they begin their careers.\n\nOur initiatives are designed to help students succeed both in and out of the classroom. These include:\n\n- **Professional development workshops** and networking events for students\n- **Academic support** through study resources\n- **Social and community-building events** to bring students together\n- **Student outreach** to inspire and engage future engineers\n- **Advocacy** for the SEG student voice within uOttawa"
         },
 
         "faq_q2": {
@@ -95,7 +95,7 @@
         "who_are_we_heading": "We're a student-led organization made up of",
         "who_are_we_heading_hl": "future tech builders",
         "who_are_we_p1_bold": "Founded in 2014",
-        "who_are_we_p1": "the Software Engineering Student Associations (SESA) helps students gain practical, hands-on experience, and make connections while still in university.",
+        "who_are_we_p1": "the Software Engineering Student's Association (SESA) helps students gain practical, hands-on experience, and make connections while still in university.",
         "who_are_we_p2_bold": "Partnered with the Faculity of Engineering, we address challenges",
         "who_are_we_p2": "in academic support, professional development, and engagement with the software engineering industry.",
         "figure_eecs_students": "EECS students",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -16,7 +16,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "About | Software Engineering Student Association",
+    title: "About | Software Engineering Student's Association",
     description: "The about page for the University of Ottawa's SESA.",
     alternates: {
         canonical: "/about",
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "About | Software Engineering Student Association",
+        title: "About | Software Engineering Student's Association",
         description: "The about page for the University of Ottawa's SESA.",
         url: new URL("https://sesa-aegl.ca/about"),
     },

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Contact | Software Engineering Student Association",
+    title: "Contact | Software Engineering Student's Association",
     description: "The contact page for the University of Ottawa's SESA.",
     alternates: {
         canonical: "/contact",
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Contact | Software Engineering Student Association",
+        title: "Contact | Software Engineering Student's Association",
         description: "The contact page for the University of Ottawa's SESA.",
         url: new URL("https://sesa-aegl.ca/contact"),
     },

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -11,7 +11,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Events | Software Engineering Student Association",
+    title: "Events | Software Engineering Student's Association",
     description: "Stay up to date on SESA's events at the University of Ottawa.",
     alternates: {
         canonical: "/events",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Events | Software Engineering Student Association",
+        title: "Events | Software Engineering Student's Association",
         description: "Stay up to date on SESA's events at the University of Ottawa.",
         url: new URL("https://sesa-aegl.ca/events"),
     },

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -25,13 +25,13 @@ const raleway = Raleway({
 });
 
 export const metadata: Metadata = {
-    title: "Software Engineering Student Association",
+    title: "Software Engineering Student's Association",
     description: "The official website for the University of Ottawa's SESA.",
     keywords: ["uottawa", "sesa", "software", "students", "seg"],
     metadataBase: new URL("https://sesa-aegl.ca"),
     openGraph: {
-        title: "Software Engineering Student Association",
-        siteName: "Software Engineering Student Association",
+        title: "Software Engineering Student's Association",
+        siteName: "Software Engineering Student's Association",
         description: "The official website for the University of Ottawa's SESA.",
         type: "website",
         url: new URL("https://sesa-aegl.ca"),

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -14,7 +14,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Home | Software Engineering Student Association",
+    title: "Home | Software Engineering Student's Association",
     alternates: {
         canonical: "/",
         languages: {

--- a/src/app/[locale]/policies/page.tsx
+++ b/src/app/[locale]/policies/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Policies | Software Engineering Student Association",
+    title: "Policies | Software Engineering Student's Association",
     description: "Policies for our website.",
     alternates: {
         canonical: "/policies",
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Policies | Software Engineering Student Association",
+        title: "Policies | Software Engineering Student's Association",
         description: "Policies for our website.",
         url: new URL("https://sesa-aegl.ca/policies"),
     },

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -10,7 +10,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Resources | Software Engineering Student Association",
+    title: "Resources | Software Engineering Student's Association",
     description: "Stay prepared with SESA's resources at the University of Ottawa.",
     alternates: {
         canonical: "/resources",
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Resources | Software Engineering Student Association",
+        title: "Resources | Software Engineering Student's Association",
         description: "Stay prepared with SESA's resources at the University of Ottawa.",
         url: new URL("https://sesa-aegl.ca/resources"),
     },

--- a/src/app/[locale]/sponsors/page.tsx
+++ b/src/app/[locale]/sponsors/page.tsx
@@ -13,7 +13,7 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Sponsors | Software Engineering Student Association",
+    title: "Sponsors | Software Engineering Student's Association",
     description: "The sponsors page for the University of Ottawa's SESA.",
     alternates: {
         canonical: "/sponsors",
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Sponsors | Software Engineering Student Association",
+        title: "Sponsors | Software Engineering Student's Association",
         description: "The sponsors page for the University of Ottawa's SESA.",
         url: new URL("https://sesa-aegl.ca/sponsors"),
     },

--- a/src/app/[locale]/thank_you/page.tsx
+++ b/src/app/[locale]/thank_you/page.tsx
@@ -8,8 +8,8 @@ import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
 export const metadata: Metadata = {
-    title: "Thank You | Software Engineering Student Association",
-    description: "Thank you for contacting the Software Engineering Student Association!",
+    title: "Thank You | Software Engineering Student's Association",
+    description: "Thank you for contacting the Software Engineering Student's Association!",
     alternates: {
         canonical: "/thank_you",
         languages: {
@@ -18,8 +18,8 @@ export const metadata: Metadata = {
         },
     },
     openGraph: {
-        title: "Thank You | Software Engineering Student Association",
-        description: "Thank you for contacting the Software Engineering Student Association!",
+        title: "Thank You | Software Engineering Student's Association",
+        description: "Thank you for contacting the Software Engineering Student's Association!",
         url: new URL("https://sesa-aegl.ca/thank_you"),
     },
 };


### PR DESCRIPTION
# Description

<!-- Summarize the changes made in this PR. If it closes an issue, use "Closes #issue" to link it -->

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [ ] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [ ] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [ ] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [ ] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [ ] Any new or modified pages export a metadata key

## Backend

- [ ] API request bodies are validated with Zod
- [ ] Sensitive configuration is managed through environment variables
- [ ] Inputs and outputs are properly sanitized where relevant (eg. DOMPurify for untrusted HTML)
