### PR TITLE
Add event calendar export

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -217,7 +217,9 @@
         "time_filter_all": "All",
         "time_filter_past": "Past",
         "time_filter_today": "Today",
-        "time_filter_upcoming": "Upcoming"
+        "time_filter_upcoming": "Upcoming",
+
+        "calendar_export": "The event information has been downloaded in iCalendar (.ics) format.\nThis file can be imported into your preferred calendar to add the event.\n\nSee:\n\n- [Google Calendar](https://support.google.com/calendar/answer/37118)\n- [Outlook](https://support.microsoft.com/en-us/office/import-or-subscribe-to-a-calendar-in-outlook-com-or-outlook-on-the-web-cff1429c-5af6-41ec-a5b4-74f2c278e98c)\n"
     },
     "resources": {
         "resources_heading": "Resources",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -198,7 +198,7 @@
         "our_events": "Our events",
         "stay_up_to_date_hl": "Stay",
         "stay_up_to_date": "up to date",
-        "stay_up_to_date_blurb": "Add our calendar to yours to stay informed about all our activities, or select specific events you’d like to add.",
+        "stay_up_to_date_blurb": "Add our events to your calendar to never miss a moment.",
         "btn_subscribe": "+ Sync Calendar",
         "subscribe_info_line1": "Syncs with Apple, Outlook, Yahoo, or Google.",
         "subscribe_info_line2": "Unsubscribe at any time.",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@headlessui/react": "^2.2.2",
         "@radix-ui/react-accordion": "^1.2.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.87.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.8(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select':
         specifier: ^2.2.5
         version: 2.2.5(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -738,6 +741,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-accordion@1.2.8':
     resolution: {integrity: sha512-c7OKBvO36PfQIUGIjj1Wko0hH937pYFU2tR5zbIJDUsmTzHoZVHHt4bmb7OOJbzTaWJtVELKWojBHa7OcnUHmQ==}
     peerDependencies:
@@ -821,6 +827,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -843,8 +862,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -902,6 +943,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.4':
     resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2900,6 +2954,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-accordion@1.2.8(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -2978,6 +3034,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.2
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.2)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -2997,7 +3075,26 @@ snapshots:
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.3(@types/react@19.1.2)
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+
   '@radix-ui/react-focus-guards@1.1.2(@types/react@19.1.2)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.2)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
@@ -3050,6 +3147,16 @@ snapshots:
       '@types/react-dom': 19.1.3(@types/react@19.1.2)
 
   '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)

--- a/src/app/[locale]/events/components/EventCard.tsx
+++ b/src/app/[locale]/events/components/EventCard.tsx
@@ -12,6 +12,67 @@ interface EventCardProps {
     event: Event;
 }
 
+/**
+ * Escape text as required by the iCalendar format.
+ * @param text Text to escape.
+ */
+function escapeCalendarText(text: string): string {
+    return text
+        .replace(/\\/g, "\\\\") // escape backslashes first
+        .replace(/;/g, "\\;") // escape semicolons
+        .replace(/,/g, "\\,") // escape commas
+        .replace(/\r?\n/g, "\\n"); // escape newlines
+}
+
+/**
+ * Convert a JS date to an iCalendar UTC date.
+ * @param date Date to convert.
+ */
+function dateToCalendar(date: Date): string {
+    const pad = (num: number) => String(num).padStart(2, "0");
+
+    const year = date.getUTCFullYear();
+    const month = pad(date.getUTCMonth() + 1); // months are 0-indexed
+    const day = pad(date.getUTCDate());
+    const hours = pad(date.getUTCHours());
+    const minutes = pad(date.getUTCMinutes());
+    const seconds = pad(date.getUTCSeconds());
+
+    return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
+/**
+ * Generates an iCalendar file from event data.
+ * @param event Event to use.
+ * @param locale Locale to use for localized event data.
+ */
+function generateCalendarFile(event: Event, locale: "en" | "fr"): string {
+    let eventStr = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//SESA//${escapeCalendarText(event.title[locale])}//${locale.toUpperCase()}
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:${escapeCalendarText(event.id)}@sesa-aegl.ca
+SUMMARY:${escapeCalendarText(event.title[locale])}
+DESCRIPTION:${escapeCalendarText(event.description[locale])}
+DTSTART:${dateToCalendar(event.startTime)}
+DTEND:${dateToCalendar(event.endTime)}
+`;
+
+    if (event.location) eventStr += `LOCATION:${escapeCalendarText(event.location)}\n`;
+
+    eventStr += `STATUS:CONFIRMED
+BEGIN:VALARM
+TRIGGER:-PT15M
+ACTION:DISPLAY
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR`;
+
+    return eventStr;
+}
+
 export const EventCard = ({ event }: EventCardProps) => {
     const t = useTranslations("events");
     const tType = useTranslations("events.event_type");
@@ -48,9 +109,18 @@ export const EventCard = ({ event }: EventCardProps) => {
 
     // Handle "Add to Calendar" action
     const handleAddToCalendar = () => {
-        if (!isPastEvent) {
-            // Logic to add the event to the calendar
-        }
+        // Create ICS file
+        const eventStr = generateCalendarFile(event, lang);
+        const file = new Blob([eventStr], { type: "text/calendar;charset=utf-8" });
+        const url = URL.createObjectURL(file);
+
+        // Trigger download
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${event.title[lang]}.ics`;
+        a.click();
+
+        URL.revokeObjectURL(url);
     };
 
     // Handle "Show More" toggle

--- a/src/app/[locale]/events/components/EventCard.tsx
+++ b/src/app/[locale]/events/components/EventCard.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import { format } from "date-fns";
+import createDOMPurify from "dompurify";
 import { CalendarClock, MapPin } from "lucide-react";
+import { marked } from "marked";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import type { Event } from "@/schemas/events";
 
 interface EventCardProps {
@@ -82,6 +91,8 @@ export const EventCard = ({ event }: EventCardProps) => {
     const [isRegistered, setIsRegistered] = useState(false);
     const [showFullDescription, setShowFullDescription] = useState(false);
 
+    const [icsDialogOpen, setIcsDialogOpen] = useState(false);
+
     // Extract localized content
     const title = event.title[lang];
     const type = tType(event.type);
@@ -120,6 +131,9 @@ export const EventCard = ({ event }: EventCardProps) => {
         a.download = `${event.title[lang]}.ics`;
         a.click();
 
+        // Open modal explaining .ics format
+        setIcsDialogOpen(true);
+
         URL.revokeObjectURL(url);
     };
 
@@ -135,104 +149,139 @@ export const EventCard = ({ event }: EventCardProps) => {
             ? `${description.slice(0, maxDescriptionLength)}...`
             : description;
 
+    // Only create DOMPurify when in browser
+    const DOMPurify = useMemo(() => {
+        if (typeof window !== "undefined") {
+            return createDOMPurify(window);
+        }
+        return null;
+    }, []);
+
+    // Helper function to safely parse markdown
+    const parseMarkdown = (markdown: string) => {
+        const rawHTML = marked(markdown, { async: false }) as string;
+        return DOMPurify ? DOMPurify.sanitize(rawHTML) : "";
+    };
+
+    const dialogBody = parseMarkdown(t("calendar_export"));
+
     return (
-        <div className="w-min border border-gray-300 bg-gray-100 from-blueviolet-100 to-darkmagenta p-px font-heading transition-all hover:bg-gradient-to-r md:w-auto">
-            <div className="flex w-min flex-col justify-start bg-gray-100 md:w-auto md:flex-row">
-                {/* Left Side: Full-Height Image */}
-                <div>
-                    <Image
-                        src={event.image}
-                        alt={event.imageAlt[lang]}
-                        width={350}
-                        height={350}
-                        className="aspect-square h-full max-w-none object-cover"
-                    />
-                </div>
-
-                {/* Right Side: Event Details */}
-                <div className="flex flex-col justify-between p-6">
-                    {/* Event Type Badge */}
+        <>
+            <Dialog open={icsDialogOpen} onOpenChange={setIcsDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Event File Downloaded</DialogTitle>
+                        <DialogDescription>
+                            {/* biome-ignore-start lint/security/noDangerouslySetInnerHtml: HTML has been sanitized */}
+                            <div
+                                className="markdown prose prose-invert max-w-none [&>li]:mb-2 [&>p]:mb-4 [&>ul]:mb-4 [&>ul]:pl-4 [&_a:hover]:text-white [&_a]:text-purple-400 [&_a]:underline"
+                                dangerouslySetInnerHTML={{
+                                    __html: dialogBody,
+                                }}
+                            />
+                            {/* biome-ignore-end lint/security/noDangerouslySetInnerHtml: HTML has been sanitized */}
+                        </DialogDescription>
+                    </DialogHeader>
+                </DialogContent>
+            </Dialog>
+            <div className="w-min border border-gray-300 bg-gray-100 from-blueviolet-100 to-darkmagenta p-px font-heading transition-all hover:bg-gradient-to-r md:w-auto">
+                <div className="flex w-min flex-col justify-start bg-gray-100 md:w-auto md:flex-row">
+                    {/* Left Side: Full-Height Image */}
                     <div>
-                        <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta px-3 py-1 text-sm uppercase">
-                            {type}
-                        </span>
+                        <Image
+                            src={event.image}
+                            alt={event.imageAlt[lang]}
+                            width={350}
+                            height={350}
+                            className="aspect-square h-full max-w-none object-cover"
+                        />
                     </div>
 
-                    {/* Event Title */}
-                    <h3 className="mt-4 text-2xl uppercase leading-tight">{title}</h3>
-
-                    {/* Date and Location */}
-                    <div className="mt-4 flex items-start gap-4 font-mono text-white">
-                        {/* Date Box */}
-                        <div className="outline-gradient -mt-2 flex flex-col items-center justify-center border px-4 py-3">
-                            <div className="font-heading text-xs uppercase">{dayOfWeek}</div>
-                            <div className="font-heading text-xl">{day}</div>
+                    {/* Right Side: Event Details */}
+                    <div className="flex flex-col justify-between p-6">
+                        {/* Event Type Badge */}
+                        <div>
+                            <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta px-3 py-1 text-sm uppercase">
+                                {type}
+                            </span>
                         </div>
 
-                        {/* Date and Location Text with Icons */}
-                        <div className="flex flex-col gap-2 text-thistle">
-                            {/* Date and Time with Icons */}
-                            <div className="flex items-center gap-2 text-white">
-                                <CalendarClock className="h-4 w-4" />
-                                <span>
-                                    {formattedDate}, {timeRange}
-                                </span>
+                        {/* Event Title */}
+                        <h3 className="mt-4 text-2xl uppercase leading-tight">{title}</h3>
+
+                        {/* Date and Location */}
+                        <div className="mt-4 flex items-start gap-4 font-mono text-white">
+                            {/* Date Box */}
+                            <div className="outline-gradient -mt-2 flex flex-col items-center justify-center border px-4 py-3">
+                                <div className="font-heading text-xs uppercase">{dayOfWeek}</div>
+                                <div className="font-heading text-xl">{day}</div>
                             </div>
 
-                            {/* Location with Icon */}
-                            <div className="flex items-center gap-2">
-                                <MapPin className="h-4 w-4" />
-                                <span>{event.location}</span>
+                            {/* Date and Location Text with Icons */}
+                            <div className="flex flex-col gap-2 text-thistle">
+                                {/* Date and Time with Icons */}
+                                <div className="flex items-center gap-2 text-white">
+                                    <CalendarClock className="h-4 w-4" />
+                                    <span>
+                                        {formattedDate}, {timeRange}
+                                    </span>
+                                </div>
+
+                                {/* Location with Icon */}
+                                <div className="flex items-center gap-2">
+                                    <MapPin className="h-4 w-4" />
+                                    <span>{event.location}</span>
+                                </div>
                             </div>
                         </div>
-                    </div>
 
-                    {/* Event Description */}
-                    <p className="mt-4 w-full font-mono text-base text-thistle">
-                        {truncatedDescription}
-                        {description.length > maxDescriptionLength && (
-                            <button
-                                type="button"
-                                onClick={toggleDescription}
-                                className="ml-2 text-blueviolet-100 hover:underline focus:outline-none"
-                            >
-                                {showFullDescription ? "Show Less" : "Show More"}
-                            </button>
-                        )}
-                    </p>
+                        {/* Event Description */}
+                        <p className="mt-4 w-full font-mono text-base text-thistle">
+                            {truncatedDescription}
+                            {description.length > maxDescriptionLength && (
+                                <button
+                                    type="button"
+                                    onClick={toggleDescription}
+                                    className="ml-2 text-blueviolet-100 hover:underline focus:outline-none"
+                                >
+                                    {showFullDescription ? "Show Less" : "Show More"}
+                                </button>
+                            )}
+                        </p>
 
-                    {/* Buttons */}
-                    <div className="mt-6 flex w-full justify-end gap-4">
-                        {/* Details Button */}
-                        <Button
-                            className="flex items-center gap-2 font-heading uppercase"
-                            onClick={handleDetails}
-                        >
-                            {t("btn_details")}
-                        </Button>
-
-                        {/* Register Button (only for events that require registration) */}
-                        {event.registrationLink && !isRegistered && !isPastEvent && (
+                        {/* Buttons */}
+                        <div className="mt-6 flex w-full justify-end gap-4">
+                            {/* Details Button */}
                             <Button
                                 className="flex items-center gap-2 font-heading uppercase"
-                                onClick={handleRegister}
+                                onClick={handleDetails}
                             >
-                                {t("btn_register")}
+                                {t("btn_details")}
                             </Button>
-                        )}
 
-                        {/* Add to Calendar Button */}
-                        <Button
-                            className="flex items-center gap-2 font-heading uppercase"
-                            onClick={handleAddToCalendar}
-                            variant="outline"
-                        >
-                            {t("btn_calendar")}
-                        </Button>
+                            {/* Register Button (only for events that require registration) */}
+                            {event.registrationLink && !isRegistered && !isPastEvent && (
+                                <Button
+                                    className="flex items-center gap-2 font-heading uppercase"
+                                    onClick={handleRegister}
+                                >
+                                    {t("btn_register")}
+                                </Button>
+                            )}
+
+                            {/* Add to Calendar Button */}
+                            <Button
+                                className="flex items-center gap-2 font-heading uppercase"
+                                onClick={handleAddToCalendar}
+                                variant="outline"
+                            >
+                                {t("btn_calendar")}
+                            </Button>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/src/app/[locale]/events/components/EventCard.tsx
+++ b/src/app/[locale]/events/components/EventCard.tsx
@@ -174,7 +174,7 @@ export const EventCard = ({ event }: EventCardProps) => {
                         <DialogDescription>
                             {/* biome-ignore-start lint/security/noDangerouslySetInnerHtml: HTML has been sanitized */}
                             <div
-                                className="markdown prose prose-invert max-w-none [&>li]:mb-2 [&>p]:mb-4 [&>ul]:mb-4 [&>ul]:pl-4 [&_a:hover]:text-white [&_a]:text-purple-400 [&_a]:underline"
+                                className="markdown text-left prose prose-invert max-w-none [&>li]:mb-2 [&>p]:mb-4 [&>ul]:mb-4 [&>ul]:pl-4 [&_a:hover]:text-white [&_a]:text-purple-400 [&_a]:underline"
                                 dangerouslySetInnerHTML={{
                                     __html: dialogBody,
                                 }}

--- a/src/app/[locale]/resources/components/SearchFilterBar.tsx
+++ b/src/app/[locale]/resources/components/SearchFilterBar.tsx
@@ -7,7 +7,6 @@ import {
     SelectContent,
     SelectGroup,
     SelectItem,
-    SelectLabel,
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,13 +37,13 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
             ref={ref}
             className={cn(
-                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 outline-gradient bg-gray-100 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
                 className,
             )}
             {...props}
         >
             {children}
-            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <DialogPrimitive.Close className="text-white absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-thistle">
                 <X className="h-4 w-4" />
                 <span className="sr-only">Close</span>
             </DialogPrimitive.Close>
@@ -54,7 +54,7 @@ DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
-        className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+        className={cn("text-white flex flex-col space-y-1.5 text-center sm:text-left", className)}
         {...props}
     />
 );
@@ -62,7 +62,10 @@ DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
-        className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+        className={cn(
+            "text-white flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+            className,
+        )}
         {...props}
     />
 );
@@ -86,7 +89,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <DialogPrimitive.Description
         ref={ref}
-        className={cn("text-sm text-muted-foreground", className)}
+        className={cn("text-sm text-thistle", className)}
         {...props}
     />
 ));

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+            "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            className,
+        )}
+        {...props}
+    />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+    </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+        {...props}
+    />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+        {...props}
+    />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+        ref={ref}
+        className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+        {...props}
+    />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+    />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+    Dialog,
+    DialogPortal,
+    DialogOverlay,
+    DialogTrigger,
+    DialogClose,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+};


### PR DESCRIPTION
# Description

Makes the event calendar export button functional by making it download a `.ics` file.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [ ] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key