### PR TITLE
Use query parameters for resource modal state

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "next": "15.4.7",
         "node-fetch": "^3.3.2",
         "nodemailer": "^6.10.0",
+        "nuqs": "^2.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-fast-marquee": "^1.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       nodemailer:
         specifier: ^6.10.0
         version: 6.10.1
+      nuqs:
+        specifier: ^2.6.0
+        version: 2.6.0(next@15.4.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -1152,6 +1155,9 @@ packages:
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1745,6 +1751,27 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  nuqs@2.6.0:
+    resolution: {integrity: sha512-EvIKBvfJeyL8n6lxfebxoAbkHJutNsxmy1oo4noFUYNUESbnecxWxgnxXoa0/4fYiFwdEuyMQx1Z9rV0h4bnkg==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^6 || ^7
+      react-router-dom: ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
@@ -3343,6 +3370,8 @@ snapshots:
 
   '@schummar/icu-type-parser@1.21.5': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3946,6 +3975,13 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  nuqs@2.6.0(next@15.4.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.1.0
+    optionalDependencies:
+      next: 15.4.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   nwsapi@2.2.20: {}
 

--- a/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
+++ b/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
@@ -6,13 +6,14 @@ import Marquee from "react-fast-marquee";
 import ComingSoonMessage from "@/components/ComingSoonMessage";
 import { Button } from "@/components/ui/button";
 import Star from "@/components/ui/decorations/star";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 import { useResources } from "@/lib/query";
 import ResourceCard from "../../resources/components/ResourceCard/ResourceCard";
 
 const Resources = () => {
     const t = useTranslations("homepage");
     const { data: resources } = useResources();
+    const router = useRouter();
 
     return (
         <section className="relative my-10 mb-0 flex w-full flex-col gap-4 text-white md:mb-20">
@@ -78,19 +79,23 @@ const Resources = () => {
                         {/* Two rows with gap */}
                         {/* First Row */}
                         <div className="me-4 flex gap-4">
-                            {resources
-                                .slice(0, Math.ceil(resources.length / 2))
-                                .map((resource, index) => (
-                                    <div key={index}>
-                                        <ResourceCard
-                                            title={resource.title}
-                                            category={resource.category}
-                                            course={resource.course}
-                                            tier={resource.tier}
-                                            format={resource.format}
-                                        />
-                                    </div>
-                                ))}
+                            {resources.slice(0, Math.ceil(resources.length / 2)).map(resource => (
+                                <div key={resource.id}>
+                                    <ResourceCard
+                                        title={resource.title}
+                                        category={resource.category}
+                                        course={resource.course}
+                                        tier={resource.tier}
+                                        format={resource.format}
+                                        onOpen={() =>
+                                            router.push({
+                                                pathname: "/resources",
+                                                query: { resource: resource.id },
+                                            })
+                                        }
+                                    />
+                                </div>
+                            ))}
                         </div>
                         {/* Second Row */}
                         <div className="me-4 flex gap-4">

--- a/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
+++ b/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
@@ -90,7 +90,7 @@ const Resources = () => {
                                         onOpen={() =>
                                             router.push({
                                                 pathname: "/resources",
-                                                query: { resource: resource.id },
+                                                query: { id: resource.id },
                                             })
                                         }
                                     />

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,8 +2,8 @@ import { Geist, Geist_Mono, Raleway } from "next/font/google";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import "./globals.css";
-
 import { hasLocale, NextIntlClientProvider } from "next-intl";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
 import { routing } from "@/i18n/routing";
@@ -72,11 +72,13 @@ export default async function RootLayout({
                 }}
             >
                 <NextIntlClientProvider>
-                    <div className="overflow-x-hidden">
-                        <Navbar />
-                        <main>{children}</main>
-                        <Footer />
-                    </div>
+                    <NuqsAdapter>
+                        <div className="overflow-x-hidden">
+                            <Navbar />
+                            <main>{children}</main>
+                            <Footer />
+                        </div>
+                    </NuqsAdapter>
                 </NextIntlClientProvider>
             </body>
         </html>

--- a/src/app/[locale]/resources/components/ResourceList.tsx
+++ b/src/app/[locale]/resources/components/ResourceList.tsx
@@ -1,27 +1,37 @@
+"use client";
 import Image from "next/image";
-import { useState } from "react";
+import { useQueryState } from "nuqs";
+import { useMemo } from "react";
 import { ResourceCard } from "./ResourceCard/ResourceCard";
 import { ResourceModal } from "./ResourceModal";
 import type React from "react";
 import type { Resource } from "@/schemas/resources";
 
 interface ResourceListProps {
+    allResources: Resource[];
     currentResources: Resource[];
     isGridMode: boolean;
 }
 
-const ResourceList: React.FC<ResourceListProps> = ({ currentResources, isGridMode }) => {
-    const [selectedResource, setSelectedResource] = useState<Resource | null>(null);
-    const [isModalOpen, setModalOpen] = useState(false);
+const ResourceList: React.FC<ResourceListProps> = ({
+    allResources,
+    currentResources,
+    isGridMode,
+}) => {
+    // URL-based state
+    const [openResource, setOpenResource] = useQueryState("resource");
+
+    const selectedResource = useMemo(
+        () => allResources.find(resource => resource.id === openResource) ?? null,
+        [openResource, allResources.find],
+    );
 
     const openModal = (resource: Resource) => {
-        setSelectedResource(resource);
-        setModalOpen(true);
+        setOpenResource(resource.id);
     };
 
     const closeModal = () => {
-        setModalOpen(false);
-        setSelectedResource(null);
+        setOpenResource(null);
     };
 
     return (
@@ -56,7 +66,7 @@ const ResourceList: React.FC<ResourceListProps> = ({ currentResources, isGridMod
             {selectedResource && (
                 <ResourceModal
                     resource={selectedResource}
-                    isOpen={isModalOpen}
+                    isOpen={!!selectedResource}
                     onClose={closeModal}
                 />
             )}

--- a/src/app/[locale]/resources/components/ResourceList.tsx
+++ b/src/app/[locale]/resources/components/ResourceList.tsx
@@ -19,7 +19,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
     isGridMode,
 }) => {
     // URL-based state
-    const [openResource, setOpenResource] = useQueryState("resource");
+    const [openResource, setOpenResource] = useQueryState("id");
 
     const selectedResource = useMemo(
         () => allResources.find(resource => resource.id === openResource) ?? null,

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { parseAsInteger, useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import Pagination from "@/components/Pagination";
 import { useResources } from "@/lib/query";
@@ -7,7 +8,9 @@ import SearchFilterBar from "./SearchFilterBar";
 import type { Resource } from "@/schemas/resources";
 
 const ResourceSection = () => {
-    const [currentPage, setCurrentPage] = useState(1);
+    // URL-based state
+    const [currentPage, setCurrentPage] = useQueryState("page", parseAsInteger.withDefault(1));
+
     const [rowsToShow, setRowsToShow] = useState(2);
     const [isGridMode, setIsGridMode] = useState(true);
     const [searchTerm, setSearchTerm] = useState("");
@@ -154,7 +157,11 @@ const ResourceSection = () => {
             />
 
             {/* Resources Grid or Row */}
-            <ResourceList currentResources={currentResources} isGridMode={isGridMode} />
+            <ResourceList
+                allResources={resources}
+                currentResources={currentResources}
+                isGridMode={isGridMode}
+            />
 
             {/* Pagination */}
             <Pagination


### PR DESCRIPTION
# Description

Closes #195

Allows a particular resource modal to be opened by reading query params. This allows resources embedded within our page to conveniently be shared. It also allows the homepage resource cards to properly open the modal for a relevant resource.

As resource modals are opened, the URL also changes to reflect this. This means that users can easily share a resource within our own page by just opening it, and copying the URL directly from the browser.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key