### PR TITLE
Port resources modal to Radix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@headlessui/react": "^2.2.2",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@headlessui/react':
-        specifier: ^2.2.2
-        version: 2.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.8(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -454,12 +451,6 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.28':
-    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
@@ -489,13 +480,6 @@ packages:
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
     hasBin: true
-
-  '@headlessui/react@2.2.2':
-    resolution: {integrity: sha512-zbniWOYBQ8GHSUIOPY7BbdIn6PzUOq0z41RFrF30HbjsxG6Rrfk+6QulR8Kgf2Vwj2a/rE6i62q5vo+2gI5dJA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
@@ -1115,43 +1099,6 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-aria/focus@3.20.2':
-    resolution: {integrity: sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/interactions@3.25.0':
-    resolution: {integrity: sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/ssr@3.9.8':
-    resolution: {integrity: sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==}
-    engines: {node: '>= 12'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/utils@3.28.2':
-    resolution: {integrity: sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-stately/flags@3.1.1':
-    resolution: {integrity: sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==}
-
-  '@react-stately/utils@3.10.6':
-    resolution: {integrity: sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.29.0':
-    resolution: {integrity: sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
 
@@ -1161,9 +1108,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
-
   '@tanstack/query-core@5.87.1':
     resolution: {integrity: sha512-HOFHVvhOCprrWvtccSzc7+RNqpnLlZ5R6lTmngb8aq7b4rc2/jDT0w+vLdQ4lD9bNtQ+/A4GsFXy030Gk4ollA==}
 
@@ -1171,15 +1115,6 @@ packages:
     resolution: {integrity: sha512-YKauf8jfMowgAqcxj96AHs+Ux3m3bWT1oSVKamaRPXSnW2HqSznnTCEkAVqctF1e/W9R/mPcyzzINIgpOH94qg==}
     peerDependencies:
       react: ^18 || ^19
-
-  '@tanstack/react-virtual@3.13.8':
-    resolution: {integrity: sha512-meS2AanUg50f3FBSNoAdBSRAh8uS0ue01qm7zrw65KGJtiXB9QXfybqZwkh4uFpRv2iX/eu5tjcH5wqUpwYLPg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/virtual-core@3.13.8':
-    resolution: {integrity: sha512-BT6w89Hqy7YKaWewYzmecXQzcJh6HTBbKYJIIkMaNU49DZ06LoTV3z32DWWEdUsgW6n1xTmwTLs4GtWrZC261w==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -2154,9 +2089,6 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tabbable@6.2.0:
-    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
-
   tailwind-merge@3.2.0:
     resolution: {integrity: sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==}
 
@@ -2234,11 +2166,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  use-sync-external-store@1.5.0:
-    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2739,14 +2666,6 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@floating-ui/react@0.26.28(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@floating-ui/utils': 0.2.9
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      tabbable: 6.2.0
-
   '@floating-ui/utils@0.2.9': {}
 
   '@formatjs/ecma402-abstract@2.3.4':
@@ -2790,16 +2709,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
-
-  '@headlessui/react@2.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-aria/focus': 3.20.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-aria/interactions': 3.25.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@tanstack/react-virtual': 3.13.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      use-sync-external-store: 1.5.0(react@19.1.0)
 
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
@@ -3319,64 +3228,11 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-aria/focus@3.20.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@react-aria/interactions': 3.25.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-aria/utils': 3.28.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-types/shared': 3.29.0(react@19.1.0)
-      '@swc/helpers': 0.5.17
-      clsx: 2.1.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@react-aria/interactions@3.25.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@react-aria/ssr': 3.9.8(react@19.1.0)
-      '@react-aria/utils': 3.28.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-stately/flags': 3.1.1
-      '@react-types/shared': 3.29.0(react@19.1.0)
-      '@swc/helpers': 0.5.17
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@react-aria/ssr@3.9.8(react@19.1.0)':
-    dependencies:
-      '@swc/helpers': 0.5.17
-      react: 19.1.0
-
-  '@react-aria/utils@3.28.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@react-aria/ssr': 3.9.8(react@19.1.0)
-      '@react-stately/flags': 3.1.1
-      '@react-stately/utils': 3.10.6(react@19.1.0)
-      '@react-types/shared': 3.29.0(react@19.1.0)
-      '@swc/helpers': 0.5.17
-      clsx: 2.1.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@react-stately/flags@3.1.1':
-    dependencies:
-      '@swc/helpers': 0.5.17
-
-  '@react-stately/utils@3.10.6(react@19.1.0)':
-    dependencies:
-      '@swc/helpers': 0.5.17
-      react: 19.1.0
-
-  '@react-types/shared@3.29.0(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@standard-schema/spec@1.0.0': {}
 
   '@swc/helpers@0.5.15':
-    dependencies:
-      tslib: 2.8.1
-
-  '@swc/helpers@0.5.17':
     dependencies:
       tslib: 2.8.1
 
@@ -3386,14 +3242,6 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.87.1
       react: 19.1.0
-
-  '@tanstack/react-virtual@3.13.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@tanstack/virtual-core': 3.13.8
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@tanstack/virtual-core@3.13.8': {}
 
   '@types/jsdom@21.1.7':
     dependencies:
@@ -4305,8 +4153,6 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tabbable@6.2.0: {}
-
   tailwind-merge@3.2.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
@@ -4395,10 +4241,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.2
-
-  use-sync-external-store@1.5.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 

--- a/src/app/[locale]/resources/components/ResourceModal.tsx
+++ b/src/app/[locale]/resources/components/ResourceModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogPanel } from "@headlessui/react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { formatDate } from "date-fns";
 import { X } from "lucide-react";
 import Image from "next/image";
@@ -314,192 +314,204 @@ export const ResourceModal = ({ resource, isOpen, onClose }: ResourceModalProps)
     };
 
     return (
-        <Dialog
+        <DialogPrimitive.Root
             open={isOpen}
-            onClose={onClose}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/10 backdrop-blur-md"
+            onOpenChange={open => {
+                if (!open) onClose();
+            }}
         >
-            <div className="inset-0 bg-fixed" />
-            <DialogPanel className="relative z-10 w-full max-w-5xl overflow-hidden">
-                {/* Header */}
-                <div className="flex items-center justify-between p-4">
-                    <div>
-                        {/* Category Badges */}
-                        <div className="mb-4 flex gap-2 font-heading text-white">
-                            <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta p-2 text-sm uppercase">
-                                {resource.category}
-                            </span>
-                            {resource.course && (
-                                <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta p-2 text-sm uppercase">
-                                    {resource.course}
-                                </span>
-                            )}
-                        </div>
-                        <h2 className="font-heading text-2xl uppercase text-white">
-                            {resource.title}
-                        </h2>
-                    </div>
-
-                    <Button
-                        size="icon"
-                        variant="outline"
-                        className="mb-10 text-white"
-                        onClick={onClose}
-                    >
-                        <X size={20} />
-                    </Button>
-                </div>
-
-                {/* Format-specific Viewer (excluding list) */}
-                {renderViewer()}
-
-                {/* Footer */}
-                <div className="flex items-center justify-between p-4 text-sm text-thistle">
-                    <div className="flex flex-row flex-wrap items-center gap-4 font-[Monocode] text-sm text-thistle">
-                        {/* Tier */}
-                        <div
-                            className="flex items-center gap-2"
-                            ref={tierRef}
-                            role="tooltip"
-                            aria-describedby={tierTooltipId}
-                            onMouseEnter={() => setShowTierTooltip(true)}
-                            onMouseLeave={() => setShowTierTooltip(false)}
-                        >
-                            <Image
-                                src="/resources-page/description.svg"
-                                alt="Tier"
-                                width={20}
-                                height={20}
-                                className="h-5 w-5"
-                            />
-                            <span>{resource.tier}</span>
-                        </div>
-
-                        <div className="h-[14px] w-px border-r border-thistle opacity-35" />
-
-                        {/* Format */}
-                        <div className="flex items-center gap-2">
-                            <Image
-                                src="/resources-page/folder.svg"
-                                alt="Format"
-                                width={20}
-                                height={20}
-                                className="h-5 w-5"
-                            />
-                            <span className="capitalize">{resource.format}</span>
-                        </div>
-
-                        <div className="h-[14px] w-px border-r border-thistle opacity-35" />
-
-                        {/* Pricing */}
-                        <div className="flex items-center gap-2">
-                            <Image
-                                src="/resources-page/pricing.svg"
-                                alt="Pricing"
-                                width={20}
-                                height={20}
-                                className="h-5 w-5"
-                            />
-                            <span className="capitalize">{resource.pricing}</span>
-                        </div>
-
-                        <div className="h-[14px] w-px border-r border-thistle opacity-35" />
-
-                        {/* Language */}
-                        <div className="flex items-center gap-2">
-                            <Image
-                                src="/resources-page/language.svg"
-                                alt="Language"
-                                width={20}
-                                height={20}
-                                className="h-5 w-5"
-                            />
-                            <span className="capitalize">{resource.language}</span>
-                        </div>
-
-                        {/* Accessibility Feature */}
-                        {resource.accessibilityFeature && (
-                            <>
-                                <div className="h-[14px] w-px border-r border-thistle opacity-35" />
-
-                                <div className="flex items-center gap-2">
-                                    <Image
-                                        src="/resources-page/accessibility.svg"
-                                        alt="Accessibility Feature"
-                                        width={20}
-                                        height={20}
-                                        className="h-5 w-5"
-                                    />
-                                    <span className="capitalize">
-                                        {resource.accessibilityFeature}
+            <DialogPrimitive.Portal>
+                <DialogPrimitive.Content className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/10">
+                    <DialogPrimitive.Overlay className="fixed z-[-1] backdrop-blur-md w-full h-full" />
+                    <div className="inset-0 bg-fixed" />
+                    <div className="w-full max-w-5xl">
+                        {/* Header */}
+                        <div className="flex items-center w-full justify-between p-4">
+                            <div>
+                                {/* Category Badges */}
+                                <div className="mb-4 flex gap-2 font-heading text-white">
+                                    <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta p-2 text-sm uppercase">
+                                        {resource.category}
                                     </span>
+                                    {resource.course && (
+                                        <span className="cursor-pointer bg-gradient-to-r from-blueviolet-100 to-darkmagenta p-2 text-sm uppercase">
+                                            {resource.course}
+                                        </span>
+                                    )}
                                 </div>
-                            </>
-                        )}
+                                <DialogPrimitive.Title className="font-heading text-2xl uppercase text-white">
+                                    {resource.title}
+                                </DialogPrimitive.Title>
+                            </div>
 
-                        {/* Last Updated */}
-                        {resource.lastUpdated && (
-                            <>
-                                <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+                            <DialogPrimitive.Close asChild>
+                                <Button
+                                    size="icon"
+                                    variant="outline"
+                                    className="mb-10 text-white"
+                                    onClick={onClose}
+                                >
+                                    <X size={20} />
+                                </Button>
+                            </DialogPrimitive.Close>
+                        </div>
+
+                        {/* Format-specific Viewer (excluding list) */}
+                        {renderViewer()}
+
+                        {/* Footer */}
+                        <div className="flex items-center justify-between p-4 text-sm text-thistle w-full">
+                            <div className="flex flex-row flex-wrap items-center gap-4 font-[Monocode] text-sm text-thistle">
+                                {/* Tier */}
                                 <div
                                     className="flex items-center gap-2"
-                                    ref={updatedRef}
+                                    ref={tierRef}
                                     role="tooltip"
-                                    aria-describedby={updatedTooltipId}
-                                    onMouseEnter={() => setShowUpdatedTooltip(true)}
-                                    onMouseLeave={() => setShowUpdatedTooltip(false)}
+                                    aria-describedby={tierTooltipId}
+                                    onMouseEnter={() => setShowTierTooltip(true)}
+                                    onMouseLeave={() => setShowTierTooltip(false)}
                                 >
                                     <Image
-                                        src="/resources-page/last-updated.svg"
-                                        alt="Last Updated"
+                                        src="/resources-page/description.svg"
+                                        alt="Tier"
                                         width={20}
                                         height={20}
                                         className="h-5 w-5"
                                     />
-                                    <span className="capitalize">
-                                        {formatDate(resource.lastUpdated, "PP")}
-                                    </span>
+                                    <span>{resource.tier}</span>
                                 </div>
-                            </>
+
+                                <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+
+                                {/* Format */}
+                                <div className="flex items-center gap-2">
+                                    <Image
+                                        src="/resources-page/folder.svg"
+                                        alt="Format"
+                                        width={20}
+                                        height={20}
+                                        className="h-5 w-5"
+                                    />
+                                    <span className="capitalize">{resource.format}</span>
+                                </div>
+
+                                <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+
+                                {/* Pricing */}
+                                <div className="flex items-center gap-2">
+                                    <Image
+                                        src="/resources-page/pricing.svg"
+                                        alt="Pricing"
+                                        width={20}
+                                        height={20}
+                                        className="h-5 w-5"
+                                    />
+                                    <span className="capitalize">{resource.pricing}</span>
+                                </div>
+
+                                <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+
+                                {/* Language */}
+                                <div className="flex items-center gap-2">
+                                    <Image
+                                        src="/resources-page/language.svg"
+                                        alt="Language"
+                                        width={20}
+                                        height={20}
+                                        className="h-5 w-5"
+                                    />
+                                    <span className="capitalize">{resource.language}</span>
+                                </div>
+
+                                {/* Accessibility Feature */}
+                                {resource.accessibilityFeature && (
+                                    <>
+                                        <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+
+                                        <div className="flex items-center gap-2">
+                                            <Image
+                                                src="/resources-page/accessibility.svg"
+                                                alt="Accessibility Feature"
+                                                width={20}
+                                                height={20}
+                                                className="h-5 w-5"
+                                            />
+                                            <span className="capitalize">
+                                                {resource.accessibilityFeature}
+                                            </span>
+                                        </div>
+                                    </>
+                                )}
+
+                                {/* Last Updated */}
+                                {resource.lastUpdated && (
+                                    <>
+                                        <div className="h-[14px] w-px border-r border-thistle opacity-35" />
+                                        <div
+                                            className="flex items-center gap-2"
+                                            ref={updatedRef}
+                                            role="tooltip"
+                                            aria-describedby={updatedTooltipId}
+                                            onMouseEnter={() => setShowUpdatedTooltip(true)}
+                                            onMouseLeave={() => setShowUpdatedTooltip(false)}
+                                        >
+                                            <Image
+                                                src="/resources-page/last-updated.svg"
+                                                alt="Last Updated"
+                                                width={20}
+                                                height={20}
+                                                className="h-5 w-5"
+                                            />
+                                            <span className="capitalize">
+                                                {formatDate(resource.lastUpdated, "PP")}
+                                            </span>
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+
+                            {resource.format.toLowerCase() !== "list" && (
+                                <Button
+                                    className="flex flex-row items-center justify-center font-heading uppercase text-white"
+                                    asChild
+                                >
+                                    <a
+                                        href={resource.source}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        Open in New Tab
+                                        <span className="hidden ps-3 md:block">
+                                            <Image
+                                                src="/resources-page/new-tab.svg"
+                                                width="15"
+                                                height="15"
+                                                alt="Open in a new tab"
+                                            ></Image>
+                                        </span>
+                                    </a>
+                                </Button>
+                            )}
+                        </div>
+
+                        {/* Render List under footer */}
+                        {renderList()}
+
+                        {/* Render tooltips */}
+                        {showTierTooltip && (
+                            <TooltipPortal id={tierTooltipId} position={tierTooltipPos}>
+                                {getIconTooltip(resource.tier)}
+                            </TooltipPortal>
+                        )}
+
+                        {showUpdatedTooltip && (
+                            <TooltipPortal id={updatedTooltipId} position={updatedTooltipPos}>
+                                {getIconTooltip("LAST UPDATED")}
+                            </TooltipPortal>
                         )}
                     </div>
-
-                    {resource.format.toLowerCase() !== "list" && (
-                        <Button
-                            className="flex flex-row items-center justify-center font-heading uppercase text-white"
-                            asChild
-                        >
-                            <a href={resource.source} target="_blank" rel="noopener noreferrer">
-                                Open in New Tab
-                                <span className="hidden ps-3 md:block">
-                                    <Image
-                                        src="/resources-page/new-tab.svg"
-                                        width="15"
-                                        height="15"
-                                        alt="Open in a new tab"
-                                    ></Image>
-                                </span>
-                            </a>
-                        </Button>
-                    )}
-                </div>
-
-                {/* Render List under footer */}
-                {renderList()}
-
-                {/* Render tooltips */}
-                {showTierTooltip && (
-                    <TooltipPortal id={tierTooltipId} position={tierTooltipPos}>
-                        {getIconTooltip(resource.tier)}
-                    </TooltipPortal>
-                )}
-
-                {showUpdatedTooltip && (
-                    <TooltipPortal id={updatedTooltipId} position={updatedTooltipPos}>
-                        {getIconTooltip("LAST UPDATED")}
-                    </TooltipPortal>
-                )}
-            </DialogPanel>
-        </Dialog>
+                </DialogPrimitive.Content>
+            </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
     );
 };


### PR DESCRIPTION
# Description

Changes the resource modal to use Radix primitives instead of Headless UI. Reduces bundle size, since shadcn/ui already uses this.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key