### PR TITLE
Fix about page "what we do" cards on mobile

### DIFF
--- a/src/app/[locale]/about/WhatWeDoCard.tsx
+++ b/src/app/[locale]/about/WhatWeDoCard.tsx
@@ -20,7 +20,9 @@ export default function WhatWeDoCard({
     linkHref,
 }: WhatWeDoCardProps) {
     return (
-        <div className="outline-gradient w-fit backdrop-blur-lg">
+        // Setting a max width of 85vw makes sure that the user can see the next card, indicating that there is something to swipe to.
+        // Otherwise, it would be hard to notice that there are more cards
+        <div className="outline-gradient w-fit max-w-[85vw] backdrop-blur-lg">
             <Image
                 src={imageHref}
                 width={400}

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -70,7 +70,7 @@ export default function About() {
     const tOurTeam = useTranslations("about.introducing_our_team_section");
 
     return (
-        <div className="min-h-screen text-white relative ">
+        <div className="min-h-screen text-white relative">
             {/* Gradient */}
             <div className="pointer-events-none absolute left-0 top-0 h-full w-full select-none">
                 {/* Light gradient */}
@@ -277,7 +277,7 @@ export default function About() {
                     </FadeInSection>
                     {/* Cards for "What do we do" */}
                     <FadeInSection>
-                        <div className="mb-8 flex w-full max-w-[28rem] gap-6 md:justify-start">
+                        <div className="mx-0 mb-8 flex w-full max-w-[28rem] gap-3 md:gap-6 md:justify-start overflow-x-auto">
                             <WhatWeDoCard
                                 imageHref="/imgs/about/social-events.webp"
                                 icon={


### PR DESCRIPTION
# Description

Makes the cards scrollable on mobile, and changes their size to make it obvious that scrolling is possible.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key