### PR TITLE
Fix second row of resource cards on homepage

### DIFF
--- a/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
+++ b/src/app/[locale]/HomeComponents/ResourcesSection/Resources.tsx
@@ -99,13 +99,23 @@ const Resources = () => {
                         </div>
                         {/* Second Row */}
                         <div className="me-4 flex gap-4">
-                            {resources
-                                .slice(Math.ceil(resources.length / 2))
-                                .map((resource, index) => (
-                                    <div key={index}>
-                                        <ResourceCard {...resource} />
-                                    </div>
-                                ))}
+                            {resources.slice(Math.ceil(resources.length / 2)).map(resource => (
+                                <div key={resource.id}>
+                                    <ResourceCard
+                                        title={resource.title}
+                                        category={resource.category}
+                                        course={resource.course}
+                                        tier={resource.tier}
+                                        format={resource.format}
+                                        onOpen={() =>
+                                            router.push({
+                                                pathname: "/resources",
+                                                query: { id: resource.id },
+                                            })
+                                        }
+                                    />
+                                </div>
+                            ))}
                         </div>
                     </div>
                 </Marquee>


### PR DESCRIPTION
# Description

In #210, I didn't realize that the two rows of resources are actually different elements. This PR applies the changes to the first row to the second row.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [ ] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [ ] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key