### PR TITLE
Paginate resources data

### DIFF
--- a/src/app/[locale]/resources/components/ResourceList.tsx
+++ b/src/app/[locale]/resources/components/ResourceList.tsx
@@ -1,30 +1,23 @@
 "use client";
 import Image from "next/image";
 import { useQueryState } from "nuqs";
-import { useMemo } from "react";
+import { useResource } from "@/lib/query";
 import { ResourceCard } from "./ResourceCard/ResourceCard";
 import { ResourceModal } from "./ResourceModal";
 import type React from "react";
 import type { Resource } from "@/schemas/resources";
 
 interface ResourceListProps {
-    allResources: Resource[];
     currentResources: Resource[];
     isGridMode: boolean;
 }
 
-const ResourceList: React.FC<ResourceListProps> = ({
-    allResources,
-    currentResources,
-    isGridMode,
-}) => {
+const ResourceList: React.FC<ResourceListProps> = ({ currentResources, isGridMode }) => {
     // URL-based state
     const [openResource, setOpenResource] = useQueryState("id");
 
-    const selectedResource = useMemo(
-        () => allResources.find(resource => resource.id === openResource) ?? null,
-        [openResource, allResources.find],
-    );
+    // Fetch the resource
+    const { data: selectedResource } = useResource(openResource);
 
     const openModal = (resource: Resource) => {
         setOpenResource(resource.id);

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import Pagination from "@/components/Pagination";
-import { useResources } from "@/lib/query";
+import { useInfiniteResources } from "@/lib/query";
 import ResourceList from "./ResourceList";
 import SearchFilterBar from "./SearchFilterBar";
 import type { Resource } from "@/schemas/resources";
@@ -22,7 +22,22 @@ const ResourceSection = () => {
     const [sortOption, setSortOption] = useState<string>("relevance");
     const [isMobile, setIsMobile] = useState(false);
 
-    const { isPending, error, data: resources } = useResources();
+    const { isPending, isFetching, error, data, fetchNextPage } = useInfiniteResources();
+    const resources = useMemo(() => {
+        if (!data) return undefined;
+        return data.pages.flatMap(page => page.docs);
+    }, [data]);
+
+    const itemsPerRow = isGridMode ? (isMobile ? 1 : 3) : 1;
+    const resourcesPerPage = itemsPerRow * rowsToShow;
+
+    // Fetch new resources as required
+    const loadedResources = resources?.length ?? 0;
+    useEffect(() => {
+        // We do currentPage + 1 so that if the user is on the current last available page,
+        // the next page's fetch will already have started
+        if (!isFetching && loadedResources < (currentPage + 1) * resourcesPerPage) fetchNextPage();
+    }, [loadedResources, currentPage, resourcesPerPage, isFetching, fetchNextPage]);
 
     // Extract unique courses from resources for the course filter
     const availableCourses = useMemo(() => {
@@ -56,10 +71,9 @@ const ResourceSection = () => {
         return () => window.removeEventListener("resize", handleResize);
     }, []);
 
-    const itemsPerRow = isGridMode ? (isMobile ? 1 : 3) : 1;
-
     // Filter resources based on search term and filter options
-    const filteredResources = useMemo(() => {
+    const filteredResources = resources ?? [];
+    const _filteredResources = useMemo(() => {
         if (!resources) return [];
 
         return resources.filter(resource => {
@@ -83,7 +97,8 @@ const ResourceSection = () => {
     }, [resources, searchTerm, filterOptions]);
 
     // Sorting logic
-    const sortedResources = [...filteredResources].sort((a, b) => {
+    const sortedResources = filteredResources;
+    const _sortedResources = [...filteredResources].sort((a, b) => {
         const tierOrder = { c: 1, b: 2, a: 3, s: 4 };
 
         const tierA = a.tier?.toLowerCase() || "";

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -155,11 +155,7 @@ const ResourceSection = () => {
             />
 
             {/* Resources Grid or Row */}
-            <ResourceList
-                allResources={resources}
-                currentResources={currentResources}
-                isGridMode={isGridMode}
-            />
+            <ResourceList currentResources={currentResources} isGridMode={isGridMode} />
 
             {/* Pagination */}
             <Pagination

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { parseAsInteger, useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import Pagination from "@/components/Pagination";
 import { useResources } from "@/lib/query";
@@ -8,8 +7,7 @@ import SearchFilterBar from "./SearchFilterBar";
 import type { Resource } from "@/schemas/resources";
 
 const ResourceSection = () => {
-    // URL-based state
-    const [currentPage, setCurrentPage] = useQueryState("page", parseAsInteger.withDefault(1));
+    const [currentPage, setCurrentPage] = useState(1);
 
     const [rowsToShow, setRowsToShow] = useState(2);
     const [isGridMode, setIsGridMode] = useState(true);

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,8 +1,8 @@
 import { QueryClient, useQuery } from "@tanstack/react-query";
-import { collection, getDocs } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
-import { FirestoreEvent } from "@/schemas/events";
-import { FirestoreResource } from "@/schemas/resources";
+import { type Event, FirestoreEvent } from "@/schemas/events";
+import { FirestoreResource, type Resource } from "@/schemas/resources";
 
 export const queryClient = new QueryClient();
 
@@ -34,6 +34,30 @@ export const useEvents = () =>
     });
 
 /**
+ * Query function used for {@link useEvent}.
+ */
+export const fetchEvent = async (id: string) => {
+    const event = await getDoc(doc(db, "Events", id));
+    if (!event.exists()) throw new TypeError(`Requested event ${id} does not exist.`);
+    return FirestoreEvent.parse(event);
+};
+
+/**
+ * Get a single event from Firestore.
+ * Remote data is validated with Zod before returning.
+ * Any validation errors are uncaught and will be propogated.
+ */
+export const useEvent = (id: string) =>
+    useQuery({
+        queryKey: ["events", { id }],
+        queryFn: () => fetchEvent(id),
+        // Check if we have already fetched this event before making a new request
+        initialData: () =>
+            queryClient.getQueryData<Event[]>(["events"])?.find(event => event.id === id),
+        initialDataUpdatedAt: () => queryClient.getQueryState(["events"])?.dataUpdatedAt,
+    });
+
+/**
  * Query function used for {@link useResources}.
  */
 export const fetchResources = async () => {
@@ -58,4 +82,30 @@ export const useResources = () =>
     useQuery({
         queryKey: ["resources"],
         queryFn: fetchResources,
+    });
+
+/**
+ * Query function used for {@link useResource}.
+ */
+export const fetchResource = async (id: string) => {
+    const resource = await getDoc(doc(db, "Resources", id));
+    if (!resource.exists()) throw new TypeError(`Requested resource ${id} does not exist.`);
+    return FirestoreResource.parse(resource);
+};
+
+/**
+ * Get a single resource from Firestore.
+ * Remote data is validated with Zod before returning.
+ * Any validation errors are uncaught and will be propogated.
+ */
+export const useResource = (id: string) =>
+    useQuery({
+        queryKey: ["resources", { id }],
+        queryFn: () => fetchResource(id),
+        // Check if we have already fetched this resource before making a new request
+        initialData: () =>
+            queryClient
+                .getQueryData<Resource[]>(["resources"])
+                ?.find(resource => resource.id === id),
+        initialDataUpdatedAt: () => queryClient.getQueryState(["resources"])?.dataUpdatedAt,
     });

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -47,10 +47,12 @@ export const fetchEvent = async (id: string) => {
  * Remote data is validated with Zod before returning.
  * Any validation errors are uncaught and will be propogated.
  */
-export const useEvent = (id: string) =>
+export const useEvent = (id: string | null) =>
     useQuery({
+        enabled: !!id,
         queryKey: ["events", { id }],
-        queryFn: () => fetchEvent(id),
+        // biome-ignore lint/style/noNonNullAssertion: The `enabled` key ensures that this will be non-null
+        queryFn: () => fetchEvent(id!),
         // Check if we have already fetched this event before making a new request
         initialData: () =>
             queryClient.getQueryData<Event[]>(["events"])?.find(event => event.id === id),
@@ -98,10 +100,12 @@ export const fetchResource = async (id: string) => {
  * Remote data is validated with Zod before returning.
  * Any validation errors are uncaught and will be propogated.
  */
-export const useResource = (id: string) =>
+export const useResource = (id: string | null) =>
     useQuery({
+        enabled: !!id,
         queryKey: ["resources", { id }],
-        queryFn: () => fetchResource(id),
+        // biome-ignore lint/style/noNonNullAssertion: The `enabled` key ensures that this will be non-null
+        queryFn: () => fetchResource(id!),
         // Check if we have already fetched this resource before making a new request
         initialData: () =>
             queryClient

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -7,26 +7,48 @@ import { FirestoreResource } from "@/schemas/resources";
 export const queryClient = new QueryClient();
 
 /**
+ * Query function used for {@link useEvents}.
+ */
+export const fetchEvents = async () => {
+    // Fetch from Firestore
+    const docs = (await getDocs(collection(db, "Events"))).docs.map(doc => ({
+        ...doc.data(),
+        id: doc.id,
+    }));
+    // Include only valid events
+    const validated = docs
+        .map(doc => FirestoreEvent.safeParse(doc))
+        .filter(doc => doc.success)
+        .map(doc => doc.data);
+    return validated;
+};
+
+/**
  * Get events data from Firestore.
  * Remote data is validated with Zod before returning.
  */
 export const useEvents = () =>
     useQuery({
-        queryKey: ["eventsData"],
-        queryFn: async () => {
-            // Fetch from Firestore
-            const docs = (await getDocs(collection(db, "Events"))).docs.map(doc => ({
-                ...doc.data(),
-                id: doc.id,
-            }));
-            // Include only valid events
-            const validated = docs
-                .map(doc => FirestoreEvent.safeParse(doc))
-                .filter(doc => doc.success)
-                .map(doc => doc.data);
-            return validated;
-        },
+        queryKey: ["events"],
+        queryFn: fetchEvents,
     });
+
+/**
+ * Query function used for {@link useResources}.
+ */
+export const fetchResources = async () => {
+    // Fetch from Firestore
+    const docs = (await getDocs(collection(db, "Resources"))).docs.map(doc => ({
+        ...doc.data(),
+        id: doc.id,
+    }));
+    // Include only valid resources
+    const validated = docs
+        .map(doc => FirestoreResource.safeParse(doc))
+        .filter(doc => doc.success)
+        .map(doc => doc.data);
+    return validated;
+};
 
 /**
  * Get resources data from Firestore.
@@ -34,18 +56,6 @@ export const useEvents = () =>
  */
 export const useResources = () =>
     useQuery({
-        queryKey: ["resourcesData"],
-        queryFn: async () => {
-            // Fetch from Firestore
-            const docs = (await getDocs(collection(db, "Resources"))).docs.map(doc => ({
-                ...doc.data(),
-                id: doc.id,
-            }));
-            // Include only valid resources
-            const validated = docs
-                .map(doc => FirestoreResource.safeParse(doc))
-                .filter(doc => doc.success)
-                .map(doc => doc.data);
-            return validated;
-        },
+        queryKey: ["resources"],
+        queryFn: fetchResources,
     });

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,10 +1,24 @@
-import { QueryClient, useQuery } from "@tanstack/react-query";
-import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+import { QueryClient, useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import {
+    collection,
+    type DocumentSnapshot,
+    doc,
+    getDoc,
+    getDocs,
+    limit,
+    orderBy,
+    type Query,
+    query,
+    startAfter,
+} from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { type Event, FirestoreEvent } from "@/schemas/events";
 import { FirestoreResource, type Resource } from "@/schemas/resources";
 
 export const queryClient = new QueryClient();
+
+/** The number of resources to request at a time when using {@link useInfiniteResources}. */
+const RESOURCE_PAGE_SIZE = 18;
 
 /**
  * Query function used for {@link useEvents}.
@@ -61,29 +75,67 @@ export const useEvent = (id: string | null) =>
 
 /**
  * Query function used for {@link useResources}.
+ * @param cursor The document to start after for paginated search.
+ * If undefined, the entire collection is dumped.
+ * If null, then the first page of results is provided.
  */
-export const fetchResources = async () => {
+export async function fetchResources(cursor?: DocumentSnapshot | null) {
+    const coll = collection(db, "Resources");
+    let q: Query;
+
+    if (cursor) {
+        // Cursor provided; start after the cursor
+        q = query(
+            coll,
+            orderBy("createdAt", "desc"),
+            startAfter(cursor),
+            limit(RESOURCE_PAGE_SIZE),
+        );
+    } else if (cursor === null) {
+        // Cursor explicitly null; start at the beginning
+        q = query(coll, orderBy("createdAt", "desc"), limit(RESOURCE_PAGE_SIZE));
+    } else {
+        // No cursor; return everything
+        q = query(coll, orderBy("createdAt", "desc"));
+    }
+
     // Fetch from Firestore
-    const docs = (await getDocs(collection(db, "Resources"))).docs.map(doc => ({
+    const snapshot = await getDocs(q);
+    const docs = snapshot.docs.map(doc => ({
         ...doc.data(),
         id: doc.id,
     }));
     // Include only valid resources
-    const validated = docs
-        .map(doc => FirestoreResource.safeParse(doc))
-        .filter(doc => doc.success)
-        .map(doc => doc.data);
-    return validated;
-};
+    const validated = docs.map(doc => FirestoreResource.parse(doc));
+
+    return {
+        docs: validated,
+        prevCursor: cursor || null,
+        nextCursor: snapshot.docs.at(-1) || null,
+    };
+}
 
 /**
- * Get resources data from Firestore.
- * Remote data is validated with Zod before returning.
+ * Get resources data from Firestore. Remote data is validated with Zod before returning.
+ * This function gets all of the resource data at once; you likely want to use {@link useInfiniteResources}.
  */
 export const useResources = () =>
     useQuery({
         queryKey: ["resources"],
-        queryFn: fetchResources,
+        queryFn: async () => (await fetchResources()).docs,
+    });
+
+/**
+ * Gets resources from Firestore with an infinite query.
+ * Remote data is validated with Zod before returning.
+ */
+export const useInfiniteResources = () =>
+    useInfiniteQuery({
+        queryKey: ["infiniteResources"],
+        queryFn: ({ pageParam }) => fetchResources(pageParam),
+        initialPageParam: null as DocumentSnapshot | null,
+        getNextPageParam: lastPage => lastPage.nextCursor,
+        getPreviousPageParam: lastPage => lastPage.prevCursor,
     });
 
 /**


### PR DESCRIPTION
# Description

Closes #219

Implements pagination for the resources page that doesn't fetch the entire database in advance.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key