### PR TITLE
Fix canonical links

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,6 +5,25 @@
         "lang_bilingual": "Bilingual"
     },
 
+    "meta": {
+        "title_suffix": "Software Engineering Students’ Association",
+        "homepage_title": "Home",
+        "about_title": "About",
+        "about_description": "About the team at SESA.",
+        "contact_title": "Contact",
+        "contact_description": "Get in touch with the SESA team.",
+        "events_title": "Events",
+        "events_description": "Stay up to date on SESA’s events at the University of Ottawa.",
+        "policies_title": "Policies",
+        "policies_description": "Terms and conditions for the use of the SESA website.",
+        "resources_title": "Resources",
+        "resources_description": "Prepare for exams with SESA’s resources.",
+        "sponsors_title": "Sponsors",
+        "sponsors_description": "A list of our club’s sponsors.",
+        "thank_you_title": "Thank You!",
+        "thank_you_description": "Thank you for contacting us!"
+    },
+
     "homepage": {
         "we_are_sesa": "Software Engineering Students' Association",
         "bridging_the_gap_hl": "Bridging the gap",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,6 +7,7 @@
 
     "meta": {
         "title_suffix": "Software Engineering Students’ Association",
+        "default_description": "The official website for the University of Ottawa’s SESA.",
         "homepage_title": "Home",
         "about_title": "About",
         "about_description": "About the team at SESA.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -7,9 +7,10 @@
 
     "meta": {
         "title_suffix": "Association des étudiants en génie logiciel",
+        "default_description": "Le site web officiel de l’Association des étudiants en génie logiciel.",
         "homepage_title": "Accueil",
         "about_title": "À propos",
-        "about_description": "À propos de l'équipe de l’AÉGL.",
+        "about_description": "À propos de l’équipe de l’AÉGL.",
         "contact_title": "Contact",
         "contact_description": "Communiquez avec l’équipe de l’AÉGL.",
         "events_title": "Événements",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -5,6 +5,25 @@
         "lang_bilingual": "Bilingue"
     },
 
+    "meta": {
+        "title_suffix": "Association des étudiants en génie logiciel",
+        "homepage_title": "Accueil",
+        "about_title": "À propos",
+        "about_description": "À propos de l'équipe de l’AÉGL.",
+        "contact_title": "Contact",
+        "contact_description": "Communiquez avec l’équipe de l’AÉGL.",
+        "events_title": "Événements",
+        "events_description": "Restez à jour sur les événements de l’AÉGL à l’Université d’Ottawa.",
+        "policies_title": "Politiques",
+        "policies_description": "Conditions d’utilisation du site web de l’AÉGL.",
+        "resources_title": "Ressources",
+        "resources_description": "Préparez vos examens avec les ressources de l’AÉGL.",
+        "sponsors_title": "Commanditaires",
+        "sponsors_description": "Une liste des commanditaires de notre club.",
+        "thank_you_title": "Merci!",
+        "thank_you_description": "Merci de nous avoir contactés!"
+    },
+
     "homepage": {
         "we_are_sesa": "Association des Étudiants en Génie Logiciel",
         "bridging_the_gap_hl": "Réduire l'écart",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 import { useMemo } from "react";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
@@ -15,22 +16,30 @@ import WhatWeDoCard from "./WhatWeDoCard";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "About | Software Engineering Students' Association",
-    description: "The about page for the University of Ottawa's SESA.",
-    alternates: {
-        canonical: "/about",
-        languages: {
-            en: "/en/about",
-            fr: "/fr/about",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("about_title")} | ${t("title_suffix")}`;
+    const description = t("about_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/about`,
+            languages: {
+                en: "/en/about",
+                fr: "/fr/about",
+            },
         },
-    },
-    openGraph: {
-        title: "About | Software Engineering Students' Association",
-        description: "The about page for the University of Ottawa's SESA.",
-        url: new URL("https://sesa-aegl.ca/about"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/about"),
+        },
+    };
+}
 
 export default function About() {
     const memberImages = ["/imgs/team/rolf.webp", "/imgs/team/asad.webp", "/imgs/team/rayen.webp"];

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import FadeInSection from "@/components/FadeInSection";
@@ -8,22 +9,30 @@ import ContactForm from "./components/ContactForm";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Contact | Software Engineering Students' Association",
-    description: "The contact page for the University of Ottawa's SESA.",
-    alternates: {
-        canonical: "/contact",
-        languages: {
-            en: "/en/contact",
-            fr: "/fr/contact",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("contact_title")} | ${t("title_suffix")}`;
+    const description = t("contact_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/contact`,
+            languages: {
+                en: "/en/contact",
+                fr: "/fr/contact",
+            },
         },
-    },
-    openGraph: {
-        title: "Contact | Software Engineering Students' Association",
-        description: "The contact page for the University of Ottawa's SESA.",
-        url: new URL("https://sesa-aegl.ca/contact"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/contact"),
+        },
+    };
+}
 
 const Contact: React.FC = () => {
     return (

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { NextResponse } from "next/server";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import FadeInSection from "@/components/FadeInSection";
@@ -13,22 +13,30 @@ import TeamUpSection from "./components/TeamUpSection";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Events | Software Engineering Students' Association",
-    description: "Stay up to date on SESA's events at the University of Ottawa.",
-    alternates: {
-        canonical: "/events",
-        languages: {
-            en: "/en/events",
-            fr: "/fr/events",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("events_title")} | ${t("title_suffix")}`;
+    const description = t("events_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/events`,
+            languages: {
+                en: "/en/events",
+                fr: "/fr/events",
+            },
         },
-    },
-    openGraph: {
-        title: "Events | Software Engineering Students' Association",
-        description: "Stay up to date on SESA's events at the University of Ottawa.",
-        url: new URL("https://sesa-aegl.ca/events"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/events"),
+        },
+    };
+}
 
 export default async function Events() {
     const locale = await getLocale();

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import "./globals.css";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import Footer from "@/components/Footer";
 import Navbar from "@/components/Navbar";
@@ -25,32 +26,46 @@ const raleway = Raleway({
     subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-    title: "Software Engineering Students' Association",
-    description: "The official website for the University of Ottawa's SESA.",
-    keywords: ["uottawa", "sesa", "software", "students", "seg"],
-    metadataBase: new URL("https://sesa-aegl.ca"),
-    openGraph: {
-        title: "Software Engineering Students' Association",
-        siteName: "Software Engineering Students' Association",
-        description: "The official website for the University of Ottawa's SESA.",
-        type: "website",
-        url: new URL("https://sesa-aegl.ca"),
-        images: "/imgs/about/team-1.webp",
-    },
-    icons: [
-        {
-            media: "(prefers-color-scheme: light)",
-            url: "/logo-filled.svg",
-            type: "image/svg+xml",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = t("title_suffix");
+    const description = t("default_description");
+
+    // Arrays not supported by next-intl
+    const keywords = {
+        en: ["uottawa", "sesa", "software", "students", "engineering"],
+        fr: ["uottawa", "aegl", "logiciel", "étudiants", "génie"],
+    };
+
+    return {
+        title,
+        description,
+        keywords: keywords[locale as "en" | "fr"],
+        metadataBase: new URL("https://sesa-aegl.ca"),
+        openGraph: {
+            title,
+            siteName: title,
+            description,
+            type: "website",
+            url: new URL("https://sesa-aegl.ca"),
+            images: "/imgs/about/team-1.webp",
         },
-        {
-            media: "(prefers-color-scheme: dark)",
-            url: "/sesa-logo.svg",
-            type: "image/svg+xml",
-        },
-    ],
-};
+        icons: [
+            {
+                media: "(prefers-color-scheme: light)",
+                url: "/logo-filled.svg",
+                type: "image/svg+xml",
+            },
+            {
+                media: "(prefers-color-scheme: dark)",
+                url: "/sesa-logo.svg",
+                type: "image/svg+xml",
+            },
+        ],
+    };
+}
 
 export default async function RootLayout({
     children,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import localeParams from "@/app/data/locales";
 import FadeInSection from "@/components/FadeInSection";
 import { api, HydrateClient } from "@/trpc/server";
@@ -15,16 +15,21 @@ import Team from "./HomeComponents/TeamSection/Team";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Home | Software Engineering Students' Association",
-    alternates: {
-        canonical: "/",
-        languages: {
-            en: "/en",
-            fr: "/fr",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    return {
+        title: `${t("homepage_title")} | ${t("title_suffix")}`,
+        alternates: {
+            canonical: `/${locale}`,
+            languages: {
+                en: "/en",
+                fr: "/fr",
+            },
         },
-    },
-};
+    };
+}
 
 export default async function Home() {
     const locale = await getLocale();

--- a/src/app/[locale]/policies/page.tsx
+++ b/src/app/[locale]/policies/page.tsx
@@ -1,27 +1,36 @@
 // biome-ignore-all lint: lint/correctness/useUniqueElementIds: IDs are only used once and should be human-readable
 
 import { useTranslations } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Policies | Software Engineering Students' Association",
-    description: "Policies for our website.",
-    alternates: {
-        canonical: "/policies",
-        languages: {
-            en: "/en/policies",
-            fr: "/fr/policies",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("policies_title")} | ${t("title_suffix")}`;
+    const description = t("policies_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/policies`,
+            languages: {
+                en: "/en/policies",
+                fr: "/fr/policies",
+            },
         },
-    },
-    openGraph: {
-        title: "Policies | Software Engineering Students' Association",
-        description: "Policies for our website.",
-        url: new URL("https://sesa-aegl.ca/policies"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/policies"),
+        },
+    };
+}
 
 export default function Policies() {
     const t = useTranslations("terms");

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { NextResponse } from "next/server";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import FadeInSection from "@/components/FadeInSection";
@@ -11,22 +11,30 @@ import ResourceSection from "./components/ResourceSection";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Resources | Software Engineering Students' Association",
-    description: "Stay prepared with SESA's resources at the University of Ottawa.",
-    alternates: {
-        canonical: "/resources",
-        languages: {
-            en: "/en/resources",
-            fr: "/fr/resources",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("resources_title")} | ${t("title_suffix")}`;
+    const description = t("resources_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/resources`,
+            languages: {
+                en: "/en/resources",
+                fr: "/fr/resources",
+            },
         },
-    },
-    openGraph: {
-        title: "Resources | Software Engineering Students' Association",
-        description: "Stay prepared with SESA's resources at the University of Ottawa.",
-        url: new URL("https://sesa-aegl.ca/resources"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/resources"),
+        },
+    };
+}
 
 export default async function Resources() {
     const locale = await getLocale();

--- a/src/app/[locale]/sponsors/page.tsx
+++ b/src/app/[locale]/sponsors/page.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import FadeInSection from "@/components/FadeInSection";
@@ -12,22 +13,30 @@ import TestimonialsCarousel from "./components/TestimonialsCarousel";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Sponsors | Software Engineering Students' Association",
-    description: "The sponsors page for the University of Ottawa's SESA.",
-    alternates: {
-        canonical: "/sponsors",
-        languages: {
-            en: "/en/sponsors",
-            fr: "/fr/sponsors",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("sponsors_title")} | ${t("title_suffix")}`;
+    const description = t("sponsors_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/sponsors`,
+            languages: {
+                en: "/en/sponsors",
+                fr: "/fr/sponsors",
+            },
         },
-    },
-    openGraph: {
-        title: "Sponsors | Software Engineering Students' Association",
-        description: "The sponsors page for the University of Ottawa's SESA.",
-        url: new URL("https://sesa-aegl.ca/sponsors"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/sponsors"),
+        },
+    };
+}
 
 const Sponsors = () => {
     const t = useTranslations("sponsorships");

--- a/src/app/[locale]/thank_you/page.tsx
+++ b/src/app/[locale]/thank_you/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { getLocale, getTranslations } from "next-intl/server";
 // Precompile i18n
 import localeParams from "@/app/data/locales";
 import { Button } from "@/components/ui/button";
@@ -7,22 +8,30 @@ import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 export const generateStaticParams = localeParams;
 
-export const metadata: Metadata = {
-    title: "Thank You | Software Engineering Students' Association",
-    description: "Thank you for contacting the Software Engineering Students' Association!",
-    alternates: {
-        canonical: "/thank_you",
-        languages: {
-            en: "/en/thank_you",
-            fr: "/fr/thank_you",
+export async function generateMetadata(): Promise<Metadata> {
+    const locale = await getLocale();
+    const t = await getTranslations("meta");
+
+    const title = `${t("thank_you_title")} | ${t("title_suffix")}`;
+    const description = t("thank_you_description");
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: `/${locale}/thank_you`,
+            languages: {
+                en: "/en/thank_you",
+                fr: "/fr/thank_you",
+            },
         },
-    },
-    openGraph: {
-        title: "Thank You | Software Engineering Students' Association",
-        description: "Thank you for contacting the Software Engineering Students' Association!",
-        url: new URL("https://sesa-aegl.ca/thank_you"),
-    },
-};
+        openGraph: {
+            title,
+            description,
+            url: new URL("https://sesa-aegl.ca/thank_you"),
+        },
+    };
+}
 
 const ThankYou = () => {
     return (


### PR DESCRIPTION
# Description

Properly localizes canonical links and other OG metadata.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [ ] All of my translations have been peer-reviewed
  - Needs review
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key