### PR TITLE
Increase stale time for queries

### DIFF
--- a/src/trpc/query-client.ts
+++ b/src/trpc/query-client.ts
@@ -8,9 +8,8 @@ export const createQueryClient = () =>
     new QueryClient({
         defaultOptions: {
             queries: {
-                // With SSR, we usually want to set some default staleTime
-                // above 0 to avoid refetching immediately on the client
-                staleTime: 30 * 1000,
+                // Our data changes very rarely; this doesn't need to be high
+                staleTime: 30 * 60 * 1000,
             },
             dehydrate: {
                 serializeData: SuperJSON.serialize,


### PR DESCRIPTION
Our data changes very rarely. There is no reason to have the timeout be 30 seconds.