### PR TITLE
Use query state for filters on resources page

### DIFF
--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -47,7 +47,7 @@ const ResourceSection = () => {
 
     const [rowsToShow, setRowsToShow] = useState(2);
     const [isGridMode, setIsGridMode] = useState(true);
-    const [searchTerm, setSearchTerm] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useQueryState("search");
     const debouncedSearchTerm = useDebounce(searchTerm || null, 300);
 
     const [filterOptions, setFilterOptions] = useQueryStates({

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -134,7 +134,7 @@ const ResourceSection = () => {
                 searchTerm={searchTerm}
                 setSearchTerm={setSearchTerm}
                 filterOptions={filterOptions}
-                setFilterOptions={setFilterOptions}
+                setFilterOptions={setFilterOptions as (options: ResourceFilters) => void}
                 sortOption={sortOption}
                 setSortOption={setSortOption}
                 isMobile={isMobile}

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useTranslations } from "next-intl";
 import {
+    createParser,
     parseAsInteger,
     parseAsString,
     parseAsStringLiteral,
@@ -14,6 +15,29 @@ import { api } from "@/trpc/react";
 import ResourceList from "./ResourceList";
 import SearchFilterBar from "./SearchFilterBar";
 import type { ResourceFilters, ResourceSorts } from "@/server/api/routers/resource";
+
+const TIER_MAP = ["S", "A", "B", "C", "D", "E", "F"] as const;
+const REVERSE_TIER_MAP = {
+    S: 0,
+    A: 1,
+    B: 2,
+    C: 3,
+    D: 4,
+    E: 5,
+    F: 6,
+} as const;
+
+const parseAsTier = createParser<0 | 1 | 2 | 3 | 4 | 5 | 6>({
+    parse(value) {
+        if (value in REVERSE_TIER_MAP)
+            return REVERSE_TIER_MAP[value as keyof typeof REVERSE_TIER_MAP];
+        return null;
+    },
+
+    serialize(value) {
+        return TIER_MAP[value];
+    },
+});
 
 const ResourceSection = () => {
     // URL-based state
@@ -31,7 +55,7 @@ const ResourceSection = () => {
         category: parseAsString,
         format: parseAsString,
         locale: parseAsStringLiteral(["en", "fr"] as const),
-        tier: parseAsInteger,
+        tier: parseAsTier,
     }) satisfies [ResourceFilters, unknown];
 
     const [sortOption, setSortOption] = useQueryState<ResourceSorts>(

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -2,7 +2,6 @@
 import { useTranslations } from "next-intl";
 import {
     createParser,
-    parseAsInteger,
     parseAsString,
     parseAsStringLiteral,
     useQueryState,
@@ -40,8 +39,7 @@ const parseAsTier = createParser<0 | 1 | 2 | 3 | 4 | 5 | 6>({
 });
 
 const ResourceSection = () => {
-    // URL-based state
-    const [currentPage, setCurrentPage] = useQueryState("page", parseAsInteger.withDefault(1));
+    const [currentPage, setCurrentPage] = useState(1);
 
     const t = useTranslations("resources");
 

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 import {
     parseAsInteger,
     parseAsString,
-    parseAsStringEnum,
+    parseAsStringLiteral,
     useQueryState,
     useQueryStates,
 } from "nuqs";
@@ -30,13 +30,13 @@ const ResourceSection = () => {
         course: parseAsString,
         category: parseAsString,
         format: parseAsString,
-        locale: parseAsStringEnum(["en", "fr"] as const),
+        locale: parseAsStringLiteral(["en", "fr"] as const),
         tier: parseAsInteger,
     }) satisfies [ResourceFilters, unknown];
 
     const [sortOption, setSortOption] = useQueryState<ResourceSorts>(
         "sort",
-        parseAsStringEnum([
+        parseAsStringLiteral([
             "created_asc",
             "created_desc",
             "updated_asc",

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslations } from "next-intl";
-import { parseAsInteger, useQueryState } from "nuqs";
+import { parseAsInteger, parseAsStringEnum, useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import Pagination from "@/components/Pagination";
 import { useDebounce } from "@/hooks";
@@ -20,7 +20,19 @@ const ResourceSection = () => {
     const [searchTerm, setSearchTerm] = useState<string | null>(null);
     const debouncedSearchTerm = useDebounce(searchTerm || null, 300);
     const [filterOptions, setFilterOptions] = useState<ResourceFilters>({});
-    const [sortOption, setSortOption] = useState<ResourceSorts>("created_desc");
+    const [sortOption, setSortOption] = useQueryState<ResourceSorts>(
+        "sort",
+        parseAsStringEnum([
+            "created_asc",
+            "created_desc",
+            "updated_asc",
+            "updated_desc",
+            "tier_asc",
+            "tier_desc",
+            "alphabetical_asc",
+            "alphabetical_desc",
+        ]).withDefault("created_desc"),
+    );
     const [isMobile, setIsMobile] = useState(false);
 
     const itemsPerRow = isGridMode ? (isMobile ? 1 : 3) : 1;

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -1,6 +1,12 @@
 "use client";
 import { useTranslations } from "next-intl";
-import { parseAsInteger, parseAsStringEnum, useQueryState } from "nuqs";
+import {
+    parseAsInteger,
+    parseAsString,
+    parseAsStringEnum,
+    useQueryState,
+    useQueryStates,
+} from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import Pagination from "@/components/Pagination";
 import { useDebounce } from "@/hooks";
@@ -19,7 +25,15 @@ const ResourceSection = () => {
     const [isGridMode, setIsGridMode] = useState(true);
     const [searchTerm, setSearchTerm] = useState<string | null>(null);
     const debouncedSearchTerm = useDebounce(searchTerm || null, 300);
-    const [filterOptions, setFilterOptions] = useState<ResourceFilters>({});
+
+    const [filterOptions, setFilterOptions] = useQueryStates({
+        course: parseAsString,
+        category: parseAsString,
+        format: parseAsString,
+        locale: parseAsStringEnum(["en", "fr"] as const),
+        tier: parseAsInteger,
+    }) satisfies [ResourceFilters, unknown];
+
     const [sortOption, setSortOption] = useQueryState<ResourceSorts>(
         "sort",
         parseAsStringEnum([

--- a/src/app/[locale]/resources/components/SearchFilterBar.tsx
+++ b/src/app/[locale]/resources/components/SearchFilterBar.tsx
@@ -123,7 +123,7 @@ export const SearchFilterBar: React.FC<SearchFilterBarProps> = ({
         [t],
     );
 
-    const hasActiveFilters = Object.values(filterOptions).some(value => value !== "");
+    const hasActiveFilters = Object.values(filterOptions).some(value => value != null);
 
     const changeView = (value: "grid" | "row") => {
         setIsGridMode(value === "grid");
@@ -139,7 +139,6 @@ export const SearchFilterBar: React.FC<SearchFilterBarProps> = ({
         let realValue: string | number = value;
         if (key === "tier") realValue = parseInt(value, 10);
         setFilterOptions({
-            ...filterOptions,
             [key]: realValue === "$none" ? undefined : realValue,
         });
     };

--- a/src/app/[locale]/resources/components/SearchFilterBar.tsx
+++ b/src/app/[locale]/resources/components/SearchFilterBar.tsx
@@ -144,7 +144,13 @@ export const SearchFilterBar: React.FC<SearchFilterBarProps> = ({
     };
 
     const clearAllFilters = () => {
-        setFilterOptions({});
+        // Explicitly set all active filters to null
+        setFilterOptions(
+            Object.keys(filterOptions).reduce((acc, key) => {
+                acc[key as keyof ResourceFilters] = null;
+                return acc;
+            }, {} as ResourceFilters),
+        );
     };
 
     return (

--- a/src/server/api/routers/resource.ts
+++ b/src/server/api/routers/resource.ts
@@ -18,15 +18,15 @@ const ResourceSorts = z.enum([
 ]);
 
 const ResourceFilters = z.object({
-    course: z.string().optional(),
-    category: z.string().optional(),
-    format: z.string().optional(),
-    locale: z.enum(["en", "fr"]).optional(),
+    course: z.string().nullish(),
+    category: z.string().nullish(),
+    format: z.string().nullish(),
+    locale: z.enum(["en", "fr"]).nullish(),
     tier: z
         .int()
         .min(0)
         .max(TIER_MAP.length - 1)
-        .optional(),
+        .nullish(),
 });
 
 export type ResourceSorts = z.infer<typeof ResourceSorts>;


### PR DESCRIPTION
# Description

Closes #211

Any filters (with the exception of search) are now stored in the query parameters.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key