### PR TITLE
Check types after linting in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,3 +33,6 @@ jobs:
 
             - name: Lint project
               run: pnpm exec biome ci
+
+            - name: Check types
+              run: pnpm exec tsc


### PR DESCRIPTION
Can help catch future deployment errors.