### PR TITLE
Enable error on warnings for CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
               run: pnpm install
 
             - name: Lint project
-              run: pnpm exec biome ci
+              run: pnpm exec biome ci --error-on-warnings
 
             - name: Check types
               run: pnpm exec tsc


### PR DESCRIPTION
Helps to be stricter.