### PR TITLE
Added resource badge onclick filtering

### DIFF
--- a/src/app/[locale]/resources/components/ResourceCard/CategoryBadges.tsx
+++ b/src/app/[locale]/resources/components/ResourceCard/CategoryBadges.tsx
@@ -2,26 +2,38 @@ export const CategoryBadges = ({
     category,
     course,
     size = "sm",
+    onBadgeClick,
 }: {
     category: string;
     course?: string | null;
     size?: "sm" | "base";
+    onBadgeClick?: (type: "category" | "course", value: string) => void;
 }) => {
     const sizeClasses = size === "sm" ? "text-xs px-3 py-2" : "text-sm p-2";
 
     return (
         <div className="flex gap-2 font-thin">
-            <span
+            <button
+                type="button"
                 className={`cursor-pointer bg-linear-to-r from-blueviolet-100 to-darkmagenta uppercase ${sizeClasses}`}
+                onClick={e => {
+                    e.stopPropagation();
+                    onBadgeClick?.("category", category);
+                }}
             >
                 {category}
-            </span>
+            </button>
             {course && (
-                <span
+                <button
+                    type="button"
                     className={`cursor-pointer bg-linear-to-r from-blueviolet-100 to-darkmagenta uppercase ${sizeClasses}`}
+                    onClick={e => {
+                        e.stopPropagation();
+                        onBadgeClick?.("course", course);
+                    }}
                 >
                     {course}
-                </span>
+                </button>
             )}
         </div>
     );

--- a/src/app/[locale]/resources/components/ResourceCard/ResourceCard.tsx
+++ b/src/app/[locale]/resources/components/ResourceCard/ResourceCard.tsx
@@ -10,6 +10,7 @@ export const ResourceCard = ({
     format,
     mode = "grid",
     onOpen,
+    onBadgeClick,
 }: {
     title: string;
     category: string;
@@ -18,6 +19,7 @@ export const ResourceCard = ({
     format: string;
     mode?: "grid" | "row";
     onOpen?: () => void;
+    onBadgeClick?: (type: "category" | "course", value: string) => void;
 }) => {
     // Row mode layout
     if (mode === "row") {
@@ -29,7 +31,12 @@ export const ResourceCard = ({
             >
                 {/* Left side - Category badges */}
                 <div className="flex min-w-fit">
-                    <CategoryBadges category={category} course={course} size="sm" />
+                    <CategoryBadges
+                        category={category}
+                        course={course}
+                        size="sm"
+                        onBadgeClick={onBadgeClick}
+                    />
                 </div>
 
                 {/* Center - Title */}
@@ -57,7 +64,12 @@ export const ResourceCard = ({
             <div className="relative flex h-full flex-col">
                 {/* Category Badges */}
                 <div className="mb-3">
-                    <CategoryBadges category={category} course={course} size="base" />
+                    <CategoryBadges
+                        category={category}
+                        course={course}
+                        size="base"
+                        onBadgeClick={onBadgeClick}
+                    />
                 </div>
 
                 {/* Title */}

--- a/src/app/[locale]/resources/components/ResourceList.tsx
+++ b/src/app/[locale]/resources/components/ResourceList.tsx
@@ -7,6 +7,7 @@ import { api } from "@/trpc/react";
 import { ResourceCard } from "./ResourceCard/ResourceCard";
 import { ResourceModal } from "./ResourceModal";
 import type React from "react";
+import type { ResourceFilters } from "@/server/api/routers/resource";
 import type { MappedResource } from "@/server/db/schema";
 
 interface ResourceListProps {
@@ -15,6 +16,8 @@ interface ResourceListProps {
     isFetching: boolean;
     hasNextPage: boolean;
     fetchNextPage: () => void;
+    setFilterOptions: (options: ResourceFilters) => void;
+    filterOptions: ResourceFilters;
 }
 
 const ResourceList: React.FC<ResourceListProps> = ({
@@ -23,6 +26,8 @@ const ResourceList: React.FC<ResourceListProps> = ({
     isFetching,
     hasNextPage,
     fetchNextPage,
+    setFilterOptions,
+    filterOptions,
 }) => {
     const t = useTranslations("resources");
 
@@ -45,6 +50,13 @@ const ResourceList: React.FC<ResourceListProps> = ({
 
     const closeModal = () => {
         setOpenResource(null);
+    };
+
+    const handleBadgeClick = (type: "category" | "course", value: string) => {
+        setFilterOptions({
+            ...filterOptions,
+            [type]: value,
+        });
     };
 
     return (
@@ -73,6 +85,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
                             {...resource}
                             mode={isGridMode ? "grid" : "row"}
                             onOpen={() => openModal(resource)}
+                            onBadgeClick={handleBadgeClick}
                         />
                     ))}
                 </div>

--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -137,6 +137,10 @@ const ResourceSection = () => {
                             isFetching={isFetching}
                             hasNextPage={hasNextPage}
                             fetchNextPage={fetchNextPage}
+                            setFilterOptions={
+                                setFilterOptions as (options: ResourceFilters) => void
+                            }
+                            filterOptions={filterOptions}
                         />
                     ) : (
                         <div className="flex justify-center items-center h-16">


### PR DESCRIPTION
# Description

closes #215 

Users can click on the course and category badges on the resource card to filter through all resources.

<!-- Summarize the changes made in this PR. If it closes an issue, use "Closes #issue" to link it -->

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key

## Backend

- [x] API request bodies are validated with Zod
- [x] Sensitive configuration is managed through environment variables
- [x] Inputs and outputs are properly sanitized where relevant (eg. DOMPurify for untrusted HTML)
