### PR TITLE
Use debounced search term for query params on resources page

### DIFF
--- a/src/app/[locale]/resources/components/ResourceSection.tsx
+++ b/src/app/[locale]/resources/components/ResourceSection.tsx
@@ -41,8 +41,18 @@ const ResourceSection = () => {
     const t = useTranslations("resources");
 
     const [isGridMode, setIsGridMode] = useState(true);
-    const [searchTerm, setSearchTerm] = useQueryState("search");
+    // The query search term is dependent on the debounced search term,
+    // but is still used at first to set the initial value of the base search term
+    const [querySearchTerm, setQuerySearchTerm] = useQueryState("search");
+    const [searchTerm, setSearchTerm] = useState<string | null>(querySearchTerm);
+
     const debouncedSearchTerm = useDebounce(searchTerm || null, 300);
+    // This is likely to cause a double-rerender when the search term changes,
+    // but it's most straightforward way I could find to keep the values in sync
+    useEffect(
+        () => void setQuerySearchTerm(debouncedSearchTerm),
+        [debouncedSearchTerm, setQuerySearchTerm],
+    );
 
     const [filterOptions, setFilterOptions] = useQueryStates({
         course: parseAsString,


### PR DESCRIPTION
# Description

Closes #260

This change seems to fix the lag problems.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key