### PR TITLE
Fix colour of overscroll area

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -451,8 +451,12 @@
         border-width: 0;
     }
 
+    html {
+        @apply bg-gray-100;
+    }
+
     body {
-        @apply m-0 leading-[normal] bg-background text-foreground;
+        @apply m-0 leading-[normal] bg-gray-100 text-foreground;
         font-family: Raleway, sans-serif;
     }
 


### PR DESCRIPTION
This makes sure that when the user scrolls past the bounds of our page, they see a colour that blends in more than the default pure white.