### PR TITLE
Animate counters for metrics on about page

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -219,25 +219,27 @@ export default function About() {
                             <div className="grid w-fit grid-cols-1 place-items-center gap-4 md:gap-20 md:grid-cols-4">
                                 <Metric
                                     className="w-64! backdrop-blur-lg"
-                                    figure="3500+"
+                                    figure={3500}
+                                    suffix="+"
                                     caption={t("figure_eecs_students")}
                                     border
                                 />
                                 <Metric
                                     className="w-64! backdrop-blur-lg"
-                                    figure="21"
+                                    figure={21}
                                     caption={t("figure_previous_partners")}
                                     border
                                 />
                                 <Metric
                                     className="w-64! backdrop-blur-lg"
-                                    figure="2300+"
+                                    figure={2300}
+                                    suffix="+"
                                     caption={t("figure_event_attendees")}
                                     border
                                 />
                                 <Metric
                                     className="w-64! backdrop-blur-lg"
-                                    figure="34"
+                                    figure={34}
                                     caption={t("figure_events")}
                                     border
                                 />

--- a/src/components/Metric.tsx
+++ b/src/components/Metric.tsx
@@ -1,6 +1,16 @@
+"use client";
+import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+import { cn } from "@/lib/utils";
+
 export interface MetricProps {
-    /** The figure to display, eg. `#10` or `3500+` */
-    figure: string;
+    /** The figure to display. */
+    figure: number;
+    /** An optional prefix before the figure. */
+    prefix?: string;
+    /** An optional suffix after the figure. */
+    suffix?: string;
     /** The caption under the figure, eg. `Ranking` or `EECS students` */
     caption?: string | undefined;
     /** Whether to add a coloured border around the component */
@@ -9,11 +19,43 @@ export interface MetricProps {
     className?: string | undefined;
 }
 
-const Metric = ({ figure, caption, border, className }: MetricProps) => {
+const Metric = ({ figure, prefix, suffix, caption, border, className }: MetricProps) => {
     const baseStyle = "py-5 px-10 text-center w-min h-min";
+
+    const { ref, inView } = useInView({
+        triggerOnce: true,
+        threshold: 0.15,
+    });
+
+    // Create a motion value starting at 0
+    const count = useMotionValue(0);
+
+    // Create a spring animation with ease-in-out feel
+    const spring = useSpring(count, {
+        stiffness: 100,
+        damping: 30,
+        restDelta: 0.001,
+    });
+
+    // Transform the spring value to rounded integers
+    const display = useTransform(
+        spring,
+        current => `${prefix ?? ""}${Math.round(current).toLocaleString()}${suffix ?? ""}`,
+    );
+
+    useEffect(() => {
+        // Animate to figure value once the user scrolls the metric into view
+        if (inView) {
+            const controls = count.set(figure);
+            return () => controls;
+        }
+    }, [figure, count, inView]);
+
     return (
-        <div className={`${baseStyle} ${className || ""} ${border && "outline-gradient"}`}>
-            <span className="font-heading text-3xl">{figure}</span>
+        <div className={cn(baseStyle, border && "outline-gradient", className)}>
+            <motion.span ref={ref} className="font-heading text-3xl">
+                {display}
+            </motion.span>
             {caption && (
                 <p className="whitespace-nowrap font-sans text-lg text-thistle">{caption}</p>
             )}


### PR DESCRIPTION
# Description

Closes #269

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key