### PR TITLE
Enable CI to run on merge groups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     push:
         branches:
             - main
+    merge_group:
 
 jobs:
     lint:


### PR DESCRIPTION
Using merge groups will help us make sure that any pull request changes have been tested in their merged state. This should help catch any errors that could happen as a result of a PR on an old commit that was unaware of new changes. The CI on that PR might pass, but if it is based on an old commit that has some outdated logic, the merged result might fail.