### PR TITLE
Prefetch course list for resources page

### DIFF
--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -53,6 +53,8 @@ export default async function Resources() {
         sort: "created_desc",
     });
 
+    void api.resource.getUniqueCourses.prefetch();
+
     return (
         <HydrateClient>
             <div className="min-h-screen text-white">


### PR DESCRIPTION
# Description

Used to populate the course filters.

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key