### PR TITLE
Add `www.` to meta URLs

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/about"),
+            url: new URL("https://www.sesa-aegl.ca/about"),
         },
     };
 }

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/contact"),
+            url: new URL("https://www.sesa-aegl.ca/contact"),
         },
     };
 }

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/events"),
+            url: new URL("https://www.sesa-aegl.ca/events"),
         },
     };
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -45,13 +45,13 @@ export async function generateMetadata(): Promise<Metadata> {
         title,
         description,
         keywords: keywords[locale as "en" | "fr"],
-        metadataBase: new URL("https://sesa-aegl.ca"),
+        metadataBase: new URL("https://www.sesa-aegl.ca"),
         openGraph: {
             title,
             siteName: title,
             description,
             type: "website",
-            url: new URL("https://sesa-aegl.ca"),
+            url: new URL("https://www.sesa-aegl.ca"),
             images: "/imgs/about/team-1.webp",
         },
         icons: [

--- a/src/app/[locale]/policies/page.tsx
+++ b/src/app/[locale]/policies/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/policies"),
+            url: new URL("https://www.sesa-aegl.ca/policies"),
         },
     };
 }

--- a/src/app/[locale]/resources/page.tsx
+++ b/src/app/[locale]/resources/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/resources"),
+            url: new URL("https://www.sesa-aegl.ca/resources"),
         },
     };
 }

--- a/src/app/[locale]/sponsors/page.tsx
+++ b/src/app/[locale]/sponsors/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/sponsors"),
+            url: new URL("https://www.sesa-aegl.ca/sponsors"),
         },
     };
 }

--- a/src/app/[locale]/thank_you/page.tsx
+++ b/src/app/[locale]/thank_you/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
         openGraph: {
             title,
             description,
-            url: new URL("https://sesa-aegl.ca/thank_you"),
+            url: new URL("https://www.sesa-aegl.ca/thank_you"),
         },
     };
 }


### PR DESCRIPTION
# Description

Closes #290

# Checklist

Check off any applicable boxes for the change being made.

## Frontend

- [x] I have made sure that any user-facing text uses **translation keys** rather than being hard-coded
- [x] All of my translations have been peer-reviewed <!-- This can be left unchecked until we have an initial site-wide translation -->
- [x] Any new or modified pages **do not** have `"use client"` in `page.tsx` <!-- Client-side parts of a page belong in their own files -->
- [x] Any new or modified pages use SSG for i18n keys via the following snippet:
    ```typescript
    // Precompile i18n
    import localeParams from "@/app/data/locales";
    export const generateStaticParams = localeParams;
    ```
- [x] Any new or modified pages export a metadata key