### PR TITLE
Tweak database indexes

### DIFF
--- a/drizzle/0003_colossal_millenium_guard.sql
+++ b/drizzle/0003_colossal_millenium_guard.sql
@@ -1,0 +1,10 @@
+DROP INDEX "resources_locale_idx";--> statement-breakpoint
+DROP INDEX "resources_pricing_idx";--> statement-breakpoint
+DROP INDEX "resources_tier_idx";--> statement-breakpoint
+DROP INDEX "resources_created_at_idx";--> statement-breakpoint
+DROP INDEX "resources_updated_at_idx";--> statement-breakpoint
+CREATE INDEX "resources_accessibility_gin_idx" ON "resources" USING gin ("accessibility");--> statement-breakpoint
+CREATE INDEX "resources_tier_id_idx" ON "resources" USING btree ("tier","id");--> statement-breakpoint
+CREATE INDEX "resources_created_at_id_idx" ON "resources" USING btree ("created_at","id");--> statement-breakpoint
+CREATE INDEX "resources_updated_at_id_idx" ON "resources" USING btree ("updated_at","id");--> statement-breakpoint
+CREATE INDEX "resources_title_id_idx" ON "resources" USING btree ("title","id");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,560 @@
+{
+    "id": "72b8276e-64cf-46bb-8a2f-60980798a26a",
+    "prevId": "80ef5972-4062-4e7b-b79d-603f3d903861",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.events": {
+            "name": "events",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "start_time": {
+                    "name": "start_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_time": {
+                    "name": "end_time",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "image_url": {
+                    "name": "image_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "details_url": {
+                    "name": "details_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "registration_url": {
+                    "name": "registration_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "events_start_time_idx": {
+                    "name": "events_start_time_idx",
+                    "columns": [
+                        {
+                            "expression": "start_time",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "events_end_time_idx": {
+                    "name": "events_end_time_idx",
+                    "columns": [
+                        {
+                            "expression": "end_time",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "events_type_idx": {
+                    "name": "events_type_idx",
+                    "columns": [
+                        {
+                            "expression": "type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "events_created_at_idx": {
+                    "name": "events_created_at_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "events_updated_at_idx": {
+                    "name": "events_updated_at_idx",
+                    "columns": [
+                        {
+                            "expression": "updated_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.events_i18n": {
+            "name": "events_i18n",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "event_id": {
+                    "name": "event_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "locale": {
+                    "name": "locale",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "image_alt": {
+                    "name": "image_alt",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "events_i18n_event_id_idx": {
+                    "name": "events_i18n_event_id_idx",
+                    "columns": [
+                        {
+                            "expression": "event_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "events_i18n_locale_idx": {
+                    "name": "events_i18n_locale_idx",
+                    "columns": [
+                        {
+                            "expression": "locale",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "events_i18n_event_id_events_id_fk": {
+                    "name": "events_i18n_event_id_events_id_fk",
+                    "tableFrom": "events_i18n",
+                    "tableTo": "events",
+                    "columnsFrom": ["event_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "events_i18n_locale_event_id_unique": {
+                    "name": "events_i18n_locale_event_id_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["locale", "event_id"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.resources": {
+            "name": "resources",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "gen_random_uuid()"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp with time zone",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "source": {
+                    "name": "source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "tier": {
+                    "name": "tier",
+                    "type": "smallint",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "locale": {
+                    "name": "locale",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "accessibility": {
+                    "name": "accessibility",
+                    "type": "text[]",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "category": {
+                    "name": "category",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "course": {
+                    "name": "course",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "pricing": {
+                    "name": "pricing",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "format": {
+                    "name": "format",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "resources_category_idx": {
+                    "name": "resources_category_idx",
+                    "columns": [
+                        {
+                            "expression": "category",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_format_idx": {
+                    "name": "resources_format_idx",
+                    "columns": [
+                        {
+                            "expression": "format",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_course_idx": {
+                    "name": "resources_course_idx",
+                    "columns": [
+                        {
+                            "expression": "course",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_locale_gin_idx": {
+                    "name": "resources_locale_gin_idx",
+                    "columns": [
+                        {
+                            "expression": "locale",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "gin",
+                    "with": {}
+                },
+                "resources_accessibility_gin_idx": {
+                    "name": "resources_accessibility_gin_idx",
+                    "columns": [
+                        {
+                            "expression": "accessibility",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "gin",
+                    "with": {}
+                },
+                "resources_tier_id_idx": {
+                    "name": "resources_tier_id_idx",
+                    "columns": [
+                        {
+                            "expression": "tier",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_created_at_id_idx": {
+                    "name": "resources_created_at_id_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_updated_at_id_idx": {
+                    "name": "resources_updated_at_id_idx",
+                    "columns": [
+                        {
+                            "expression": "updated_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_title_id_idx": {
+                    "name": "resources_title_id_idx",
+                    "columns": [
+                        {
+                            "expression": "title",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "resources_title_trgm_idx": {
+                    "name": "resources_title_trgm_idx",
+                    "columns": [
+                        {
+                            "expression": "\"title\" gin_trgm_ops",
+                            "asc": true,
+                            "isExpression": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "gin",
+                    "with": {}
+                },
+                "resources_course_trgm_idx": {
+                    "name": "resources_course_trgm_idx",
+                    "columns": [
+                        {
+                            "expression": "\"course\" gin_trgm_ops",
+                            "asc": true,
+                            "isExpression": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "gin",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
             "when": 1757561135741,
             "tag": "0002_wise_wolverine",
             "breakpoints": true
+        },
+        {
+            "idx": 3,
+            "version": "7",
+            "when": 1770699116142,
+            "tag": "0003_colossal_millenium_guard",
+            "breakpoints": true
         }
     ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -81,16 +81,22 @@ export const resources = pgTable(
         format: text("format").notNull(),
     },
     t => [
-        index("resources_locale_idx").on(t.locale),
-        index("resources_locale_gin_idx").using("gin", t.locale),
+        // Basic filtering
         index("resources_category_idx").on(t.category),
-        index("resources_course_idx").on(t.course),
-        index("resources_pricing_idx").on(t.pricing),
         index("resources_format_idx").on(t.format),
-        index("resources_tier_idx").on(t.tier),
-        index("resources_created_at_idx").on(t.createdAt),
-        index("resources_updated_at_idx").on(t.updatedAt),
-        // For full-text search
+        index("resources_course_idx").on(t.course),
+
+        // Array containment searching
+        index("resources_locale_gin_idx").using("gin", t.locale),
+        index("resources_accessibility_gin_idx").using("gin", t.accessibility),
+
+        // Sorting with ID as tiebreaker
+        index("resources_tier_id_idx").on(t.tier, t.id),
+        index("resources_created_at_id_idx").on(t.createdAt, t.id),
+        index("resources_updated_at_id_idx").on(t.updatedAt, t.id),
+        index("resources_title_id_idx").on(t.title, t.id),
+
+        // Full-text search
         index("resources_title_trgm_idx").using("gin", sql`${t.title} gin_trgm_ops`),
         index("resources_course_trgm_idx").using("gin", sql`${t.course} gin_trgm_ops`),
     ],


### PR DESCRIPTION
Updates the indexes used by the database to reflect the actual queries that we use (e.g. using `id` as a tiebreaker field for sorting). Should improve read performance. `EXPLAIN` queries currently show that the indexes aren't even being used for the sorting on the resources page (presumably since it is faster with our current DB size to just do a sort rather than composing separate indexes)