### PR TITLE
Fix Highlight over Text (#310)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "biomejs.biome",
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    }
 }

--- a/src/app/[locale]/resources/components/FooterSection.tsx
+++ b/src/app/[locale]/resources/components/FooterSection.tsx
@@ -81,9 +81,7 @@ const FooterSection: React.FC = () => {
                 <div className="z-10 mx-5 max-w-lg text-left text-white">
                     <div className="font-heading text-2xl uppercase">
                         “{t("education_quote_1")}{" "}
-                        <span className="highlight-text">
-                            {t("education_quote_1_hl")}
-                        </span>{" "}
+                        <span className="highlight-text">{t("education_quote_1_hl")}</span>{" "}
                         {t("education_quote_2")}.”
                     </div>
                     <div className="my-3 flex items-center gap-4">
@@ -95,20 +93,13 @@ const FooterSection: React.FC = () => {
                             height={50}
                         />
                         <div>
-                            <p className="z-20 mt-4 font-heading text-xl">
-                                ANGE EMMANUEL
-                            </p>
-                            <p className="text-sm opacity-70">
-                                {t("academic_lead")}
-                            </p>
+                            <p className="z-20 mt-4 font-heading text-xl">ANGE EMMANUEL</p>
+                            <p className="text-sm opacity-70">{t("academic_lead")}</p>
                         </div>
                     </div>
                     {/* Call To Action Button */}
                     <div className="mt-6">
-                        <Button
-                            asChild
-                            className="relative z-10 font-heading text-lg uppercase"
-                        >
+                        <Button asChild className="relative z-10 font-heading text-lg uppercase">
                             <Link href="/about" className="block text-inherit">
                                 {t("btn_meet_the_team")}
                             </Link>

--- a/src/app/[locale]/sponsors/components/Benefits.tsx
+++ b/src/app/[locale]/sponsors/components/Benefits.tsx
@@ -78,11 +78,11 @@ export default function Benefits() {
     const cardWidthVW = isMobile ? 60 : 28;
 
     const handlePrev = () => {
-        setCurrentIndex((prev) => (prev === 0 ? cards.length - 1 : prev - 1));
+        setCurrentIndex(prev => (prev === 0 ? cards.length - 1 : prev - 1));
     };
 
     const handleNext = () => {
-        setCurrentIndex((prev) => (prev === cards.length - 1 ? 0 : prev + 1));
+        setCurrentIndex(prev => (prev === cards.length - 1 ? 0 : prev + 1));
     };
 
     return (
@@ -109,15 +109,9 @@ export default function Benefits() {
                         {t("benefits_top")}
                     </p>
                     <h2 className="mb-4 font-heading text-2xl text-white uppercase md:text-3xl">
-                        <span className="block md:inline">
-                            {t("benefits_title_part1")}
-                        </span>{" "}
-                        <span className="highlight-text">
-                            {t("benefits_title_highlight")}
-                        </span>{" "}
-                        <span className="block md:inline">
-                            {t("benefits_title_part3")}
-                        </span>
+                        <span className="block md:inline">{t("benefits_title_part1")}</span>{" "}
+                        <span className="highlight-text">{t("benefits_title_highlight")}</span>{" "}
+                        <span className="block md:inline">{t("benefits_title_part3")}</span>
                     </h2>
 
                     <p className="max-w-full text-base text-thistle leading-tight md:mb-4 md:max-w-2xl md:text-lg">
@@ -163,11 +157,7 @@ export default function Benefits() {
                             <div className="flex h-full flex-col overflow-hidden border border-solid text-left text-white backdrop-blur-super [border-image:linear-gradient(55deg,rgba(136,36,220,0.3)_41.93%,rgba(177,33,157,0.3)_81.89%)_1]">
                                 <Image
                                     src={card.image}
-                                    alt={
-                                        locale === "fr"
-                                            ? card.title.fr
-                                            : card.title.en
-                                    }
+                                    alt={locale === "fr" ? card.title.fr : card.title.en}
                                     width={500}
                                     height={300}
                                     className="h-40 w-full object-cover md:h-48 2xl:h-96"
@@ -184,9 +174,7 @@ export default function Benefits() {
                                             />
                                         </div>
                                         <div className="mb-2 font-heading text-base text-white uppercase leading-snug md:text-lg">
-                                            {locale === "fr"
-                                                ? card.title.fr
-                                                : card.title.en}
+                                            {locale === "fr" ? card.title.fr : card.title.en}
                                         </div>
                                         <p className="font-sans text-sm text-thistle leading-snug md:text-lg">
                                             {locale === "fr"

--- a/src/app/[locale]/sponsors/components/PastCollaboratorsCarousel.tsx
+++ b/src/app/[locale]/sponsors/components/PastCollaboratorsCarousel.tsx
@@ -71,9 +71,7 @@ const PastCollaboratorsCarousel = () => {
                     {t("past_collaborators_top")}
                 </p>
                 <h2 className="font-heading text-2xl text-white uppercase md:text-3xl">
-                    <span className="highlight-text">
-                        {t("past_collaborators_highlight")}
-                    </span>{" "}
+                    <span className="highlight-text">{t("past_collaborators_highlight")}</span>{" "}
                     {t("past_collaborators_title_rest")}
                 </h2>
                 <p className="max-w-xl text-base text-thistle md:text-lg">
@@ -83,12 +81,7 @@ const PastCollaboratorsCarousel = () => {
 
             {/* Marquee Carousel */}
             <div className="relative mt-8 w-full">
-                <Marquee
-                    speed={40}
-                    gradient={false}
-                    pauseOnHover={true}
-                    autoFill
-                >
+                <Marquee speed={40} gradient={false} pauseOnHover={true} autoFill>
                     {logos.concat(logos).map((logo, index) => (
                         <div
                             key={index}


### PR DESCRIPTION
- Fix the highlighted text that went over the text by using the appropriate class.
- Added a space after the text which looks better on larger screen (Doesn't affect mobile / french)
- Formatted

# Description
Closes #310 
- Fixed the highlight that was over the text. (2 In Sponsor page, 1 in Ressources)
- Added "typescriptreact" default formatter to the .vscode\settings (As the current vscode config wouldn't use biome otherwise)
<img width="589" height="420" alt="image" src="https://github.com/user-attachments/assets/f1f288ec-c2c2-4354-8834-1b88d407daba" />



