### PR TITLE
Disabled Instagram Carousel #323

### DIFF
--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -8,7 +8,6 @@ import Star from "@/components/decorations/star";
 import { api, HydrateClient } from "@/trpc/server";
 import ConnectSESA from "./components/ConnectSESA";
 import EventSection from "./components/EventSection";
-import InfiniteCarousel from "./components/InfiniteCarousel";
 import TeamUpSection from "./components/TeamUpSection";
 export const generateStaticParams = localeParams;
 
@@ -95,7 +94,7 @@ export default async function Events() {
                             delay={0.5}
                         />
 
-                        <InfiniteCarousel />
+                        {/* <InfiniteCarousel /> */}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# Description
Closes #323 

- Disabled Instagram Carousel, because New Instagram posts are mainly events, so content would likely be duplicated with the events page
- Commented the usage of the component and kept the component in case we want to re-use its logic.

