### PR TITLE
fix(i18n): Fix spelling of "événements"

### DIFF
--- a/apps/web/i18n/fr.json
+++ b/apps/web/i18n/fr.json
@@ -62,7 +62,7 @@
         "faq_description": "Nous avons les réponses à vos questions ci-dessous. Si vous avez encore des interrogations, contactez-nous et nous vous répondrons dans les plus brefs délais.",
         "faq_q1": {
             "title": "QU’EST-CE QUE L’AÉGL?",
-            "answer": "L'AÉGL est l'association des étudiants en génie logiciel de l'Université d'Ottawa, une organisation étudiante indépendante visant à enrichir la vie étudiante en GL, promouvoir le génie logiciel en tant que domaine, et soutenir les étudiants académiquement et professionnellement au début de leur carrière.\n\nNos initiatives ont pour but d’aider les étudiants en classe et en dehors de la classe. Elles incluent :\n\n- **Ateliers de développement professionnel** et des évènement de réseautage pour étudiants\n- **Support académique** à l’aide de ressources d’études\n- **Évenements sociaux** pour rassembler les étudiants\n- **Sensibilisation étudiante** pour inspirer et engager les futurs ingénieurs\n- **Revendication** pour les voix des étudiants de GL à uOttawa"
+            "answer": "L'AÉGL est l'association des étudiants en génie logiciel de l'Université d'Ottawa, une organisation étudiante indépendante visant à enrichir la vie étudiante en GL, promouvoir le génie logiciel en tant que domaine, et soutenir les étudiants académiquement et professionnellement au début de leur carrière.\n\nNos initiatives ont pour but d’aider les étudiants en classe et en dehors de la classe. Elles incluent :\n\n- **Ateliers de développement professionnel** et des évènement de réseautage pour étudiants\n- **Support académique** à l’aide de ressources d’études\n- **Événements sociaux** pour rassembler les étudiants\n- **Sensibilisation étudiante** pour inspirer et engager les futurs ingénieurs\n- **Revendication** pour les voix des étudiants de GL à uOttawa"
         },
         "faq_q2": {
             "title": "QUI PEUT S'Y JOINDRE ?",
@@ -164,8 +164,8 @@
             "partnerships_lead": "Responsable des partenariats",
             "partnerships_member": "Coordinateur·rice des partenariats",
 
-            "logistics_lead": "Responsable des évenements",
-            "logistics_member": "Coordinateur·rice des évenements",
+            "logistics_lead": "Responsable des événements",
+            "logistics_member": "Coordinateur·rice des événements",
 
             "advisors_lead": "Conseiller·ère",
             "advisors_member": "Conseiller·ère",


### PR DESCRIPTION
The second 'e' was missing an accent in some cases; needs to have either é or è. I went with é.